### PR TITLE
Ignore `tests` from Git export

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,7 +2,7 @@
 .gitattributes export-ignore
 .gitignore export-ignore
 .php-cs-fixer.php export-ignore
-Tests export-ignore
+tests export-ignore
 phpstan.neon export-ignore
 phpunit.xml.dist export-ignore
 composer.lock export-ignore


### PR DESCRIPTION
## Description
the `tests` folder should be excluded from export (fixing typo, currently it is `Tests`, with uppercase `T`)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] I agree that this code will be published under the [MIT license](https://github.com/kevinpapst/TablerBundle/blob/master/LICENSE)
