### PR TITLE
BugFix - login page render when default values from tabler.yaml

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -15,7 +15,7 @@ use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 /**
- * This is the class that validates and merges the AdminLTEBundle configuration
+ * This is the class that validates and merges the TablerBundle configuration
  *
  * @see http://symfony.com/doc/current/cookbook/bundles/extension.html#cookbook-bundles-extension-config-class
  */
@@ -106,7 +106,7 @@ class Configuration implements ConfigurationInterface
                     ->info('')
                 ->end()
                 ->scalarNode('main_menu')
-                    ->defaultValue('adminlte_main')
+                    ->defaultValue('tabler_main')
                     ->info('your builder alias')
                 ->end()
                 ->scalarNode('breadcrumb_menu')

--- a/templates/security.html.twig
+++ b/templates/security.html.twig
@@ -38,7 +38,7 @@
                             <label class="form-label">
                                 {{ 'Password'|trans({}, 'TablerBundle') }}
                                 {% block password_forgotten %}
-                                    {% if 'tabler_password_reset'|tabler_route != 'adminlte_password_reset' %}
+                                    {% if 'tabler_password_reset'|tabler_route != 'tabler_password_reset' %}
                                         <span class="form-label-description">
                                             <a href="{{ path('tabler_password_reset'|tabler_route) }}">{{ 'I forgot my password'|trans({}, 'TablerBundle') }}</a>
                                         </span>
@@ -93,7 +93,7 @@
 
         {% block login_actions %}
             {% block registration %}
-                {% if 'tabler_registration'|tabler_route != 'adminlte_registration' %}
+                {% if 'tabler_registration'|tabler_route != 'tabler_registration' %}
                     <div class="text-center text-muted mt-3">
                         <a href="{{ path('tabler_registration'|tabler_route) }}">
                             {{ 'Register a new account'|trans({}, 'TablerBundle') }}

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -58,7 +58,7 @@ class ConfigurationTest extends TestCase
                 ],
                 'knp_menu' => [
                     'enable' => false,
-                    'main_menu' => 'adminlte_main',
+                    'main_menu' => 'tabler_main',
                     'breadcrumb_menu' => false,
                 ],
                 'routes' => [


### PR DESCRIPTION

## Description
Remove OLD AdminLTE comparison that breaks the render when default values 
used from `tabler.yaml` to disable "register link" for example.

FIX : 
- Registration ✔️ 
- Reset password ✔️ 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] I updated the documentation (see [here](https://github.com/kevinpapst/TablerBundle/tree/master/docs))
- [x] I agree that this code will be published under the [MIT license](https://github.com/kevinpapst/TablerBundle/blob/master/LICENSE)
