### PR TITLE
Feature - Icons on child items menu

### DIFF
--- a/templates/includes/menu.html.twig
+++ b/templates/includes/menu.html.twig
@@ -12,7 +12,7 @@
                 {%- endif -%}>
                     {% if item.icon %}
                         <span class="nav-link-icon d-md-none d-lg-inline-block text-center">
-                            {{ tabler_icon(item.icon) }}
+                            {{ tabler_icon(item.icon, null, false) }}
                         </span>
                     {% endif %}
                 <span class="nav-link-title">{{ item.label|trans }}</span>
@@ -29,7 +29,7 @@
                         <a class="dropdown-item {{ child.isActive ? 'active':'' }}" href="{{ '/' in child.route ? child.route : path(child.route|tabler_route, child.routeArgs) }}">
                             {% if child.icon %}
                                 <span class="nav-link-icon d-md-none d-lg-inline-block text-center">
-                                    {{ tabler_icon(child.icon) }}
+                                    {{ tabler_icon(child.icon, null, false) }}
                                 </span>
                             {% endif %}
                             {{ child.label|trans }}

--- a/templates/includes/menu.html.twig
+++ b/templates/includes/menu.html.twig
@@ -10,11 +10,11 @@
                 {%- else -%}
                 class="nav-link" href="{{ '/' in item.route ? item.route : path(item.route|tabler_route, item.routeArgs) }}"
                 {%- endif -%}>
-                <span class="nav-link-icon d-md-none d-lg-inline-block text-center">
                     {% if item.icon %}
-                        {{ tabler_icon(item.icon) }}
+                        <span class="nav-link-icon d-md-none d-lg-inline-block text-center">
+                            {{ tabler_icon(item.icon) }}
+                        </span>
                     {% endif %}
-                </span>
                 <span class="nav-link-title">{{ item.label|trans }}</span>
             </a>
 
@@ -27,6 +27,11 @@
                             {%- endif %}
                         {% else %}
                         <a class="dropdown-item {{ child.isActive ? 'active':'' }}" href="{{ '/' in child.route ? child.route : path(child.route|tabler_route, child.routeArgs) }}">
+                            {% if child.icon %}
+                                <span class="nav-link-icon d-md-none d-lg-inline-block text-center">
+                                    {{ tabler_icon(child.icon) }}
+                                </span>
+                            {% endif %}
                             {{ child.label|trans }}
                         </a>
                         {% endif %}


### PR DESCRIPTION
## Description

Add the possibility to add `icon` on a `child item` from the menu.

Vertical:
![image](https://user-images.githubusercontent.com/25293190/145590918-2fdade24-3238-456d-866f-26e82ab1b7a8.png)

Horizontal:
![image](https://user-images.githubusercontent.com/25293190/145593511-f94f4469-fe3e-4004-8d65-02747f4c41b5.png)


### ⚠️  Note ⚠️ 

|  | Before | After |
|:---:|:---|:---|
| Comment | Items was align even if there's no icon | If no icon configured on item, the "block" is no longer present, so the label item will be put more on the left side.  |
| Result | ![image](https://user-images.githubusercontent.com/25293190/145591790-ce0dd449-8b97-4ceb-9f4f-77bf5dc84fed.png) | ![image](https://user-images.githubusercontent.com/25293190/145591979-df5b761f-e6eb-4c69-b415-2c035b589e18.png) |


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] I updated the documentation (see [here](https://github.com/kevinpapst/TablerBundle/tree/master/docs))
- [x] I agree that this code will be published under the [MIT license](https://github.com/kevinpapst/TablerBundle/blob/master/LICENSE)
