### PR TITLE
Add hasActiveChildren() on menu + auto open tree

### DIFF
--- a/src/Model/MenuItemModel.php
+++ b/src/Model/MenuItemModel.php
@@ -189,6 +189,11 @@ class MenuItemModel implements MenuItemInterface
         return null;
     }
 
+    public function hasActiveChildren(): bool
+    {
+        return null !== $this->getActiveChild();
+    }
+
     public function isActive(): bool
     {
         return $this->isActive;

--- a/templates/includes/menu.html.twig
+++ b/templates/includes/menu.html.twig
@@ -6,7 +6,7 @@
     {% for item in menu %}
         <li id="{{ item.identifier }}" class="nav-item {{ item.isActive ? 'active' : '' }} {{ item.hasChildren? 'dropdown' : '' }}">
             <a {% if item.hasChildren -%}
-                class="nav-link dropdown-toggle" href="#navbar-base" data-bs-toggle="dropdown" role="button" aria-expanded="false"
+                class="nav-link dropdown-toggle {{ item.hasActiveChildren? 'show' : '' }}" href="#navbar-base" data-bs-toggle="dropdown" role="button" aria-expanded="{{ item.hasActiveChildren? 'true' : 'false' }}"
                 {%- else -%}
                 class="nav-link" href="{{ '/' in item.route ? item.route : path(item.route|tabler_route, item.routeArgs) }}"
                 {%- endif -%}>
@@ -19,7 +19,7 @@
             </a>
 
             {% if item.hasChildren %}
-                <div class="dropdown-menu">
+                <div class="dropdown-menu {{ item.hasActiveChildren? 'show' : '' }}">
                     {% for child in item.children %}
                         {% if child.divider %}
                             {% if not loop.last -%}


### PR DESCRIPTION
## Description
Allow the menu to be auto-opened when menu item has an active child.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] I updated the documentation (see [here](https://github.com/kevinpapst/TablerBundle/tree/master/docs))
- [x] I agree that this code will be published under the [MIT license](https://github.com/kevinpapst/TablerBundle/blob/master/LICENSE)
