### PR TITLE
Card Embed - BugFix when using `_fullsize` and class name

### DIFF
--- a/templates/embeds/card.html.twig
+++ b/templates/embeds/card.html.twig
@@ -36,7 +36,7 @@
     </div>
     {% endif %}
     {% if block('box_header_after') is defined %}{{ block('box_header_after') }}{% endif %}
-    <div {% if _collapsible %}id="{{ _id }}" {% endif %}class="{% if _collapsible %}{% if _collapsed %}collapse{% else %} show{% endif %}{% endif %} card-body{% if block('box_body_class') is defined %} {{ block('box_body_class') }}{% endif %}{% if _fullsize %}p-0{% endif %}">{{ block('box_body') }}</div>
+    <div {% if _collapsible %}id="{{ _id }}" {% endif %}class="{% if _collapsible %}{% if _collapsed %} collapse{% else %} show{% endif %}{% endif %} card-body{% if block('box_body_class') is defined %} {{ block('box_body_class') }}{% endif %}{% if _fullsize %} p-0{% endif %}">{{ block('box_body') }}</div>
     {% if block('box_footer_before') is defined %}{{ block('box_footer_before') }}{% endif %}
     {% if _footer and block('box_footer') is defined %}
         {# 


### PR DESCRIPTION
## Description
BugFix when using `_fullsize`.
Class `p-0` was attached to the previous class.

Same fix for `collapse` to be more safe.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] I updated the documentation (see [here](https://github.com/kevinpapst/TablerBundle/tree/master/docs))
- [x] I agree that this code will be published under the [MIT license](https://github.com/kevinpapst/TablerBundle/blob/master/LICENSE)
