### PR TITLE
Render badge in menu

### DIFF
--- a/src/Model/MenuItemModel.php
+++ b/src/Model/MenuItemModel.php
@@ -49,8 +49,31 @@ class MenuItemModel implements MenuItemInterface
     private $badge;
     /**
      * @var string|null
+     * @deprecated
      */
     private $badgeColor;
+
+    /**
+     * @var string|null
+     */
+    private $badgeClass;
+
+    /**
+     * @return string|null
+     */
+    public function getBadgeClass(): ?string
+    {
+        return $this->badgeClass;
+    }
+
+    /**
+     * @param string|null $badgeClass
+     */
+    public function setBadgeClass(?string $badgeClass): void
+    {
+        $this->badgeClass = $badgeClass;
+    }
+
     /**
      * @var bool
      */

--- a/src/Twig/RuntimeExtension.php
+++ b/src/Twig/RuntimeExtension.php
@@ -132,4 +132,10 @@ final class RuntimeExtension implements RuntimeExtensionInterface
     {
         return ($isIcon ? 'icon ' : '') . ($this->icons[str_replace('-', '_', $name)] ?? ($default ?? $name));
     }
+
+    public function createBadge(?string $value, string $class = null): string
+    {
+        return sprintf('<span class="%s">%s</span>', $class, $value);
+    }
+
 }

--- a/src/Twig/TablerExtension.php
+++ b/src/Twig/TablerExtension.php
@@ -38,6 +38,7 @@ class TablerExtension extends AbstractExtension
             new TwigFunction('tabler_notifications', [RuntimeExtension::class, 'getNotifications']),
             new TwigFunction('tabler_user', [RuntimeExtension::class, 'getUserDetails']),
             new TwigFunction('tabler_icon', [RuntimeExtension::class, 'createIcon'], ['is_safe' => ['html']]),
+            new TwigFunction('tabler_badge', [RuntimeExtension::class, 'createBadge'], ['is_safe' => ['html']]),
         ];
     }
 }

--- a/templates/includes/menu.html.twig
+++ b/templates/includes/menu.html.twig
@@ -16,6 +16,9 @@
                         </span>
                     {% endif %}
                 <span class="nav-link-title">{{ item.label|trans }}</span>
+                {% if item.badge %}
+                    {{ tabler_badge(item.badge, item.badgeClass) }}
+                {% endif %}
             </a>
 
             {% if item.hasChildren %}


### PR DESCRIPTION
## Description

Renders the menu item badge and badge class, first step in fixing #38 

I deprecated badge color and replaced it with badge class.

While the badge now renders, there's a conflict with the .badge css in tabler.css, and I'm not sure how to fix it.  So it's functional but not very pretty.

## Types of changes
- [ X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ X ] Breaking change (fix or feature that would cause existing functionality to change)

