### PR TITLE
[Feature] Add error layout + layout fullpage

### DIFF
--- a/config/packages/tabler.yaml
+++ b/config/packages/tabler.yaml
@@ -39,10 +39,11 @@ tabler:
         collapse: fas fa-chevron-down
         # used for the password-reset template
         mail: far fa-envelope
+        # used for the 404/500/... error page
+        back: fas fa-long-arrow-alt-left
         # the following are only ideas to be used in your own templates
         about: fas fa-info-circle
         admin: fas fa-wrench
-        back: fas fa-long-arrow-alt-left
         bookmark: far fa-star
         calendar: far fa-calendar-alt
         comment: far fa-comment

--- a/docs/error_pages.md
+++ b/docs/error_pages.md
@@ -1,0 +1,18 @@
+# Using the layout
+
+In order to use the layout, your error views should extend from the provided `error layout`
+```twig
+{% extends '@Tabler/error.html.twig' %}
+```
+
+## Layout blocks
+
+TODO explain blocks
+
+## Extra
+
+You can follow the symfony tutorial to create your own error templates: https://symfony.com/doc/current/controller/error_pages.html
+
+## Next steps
+
+Please go back to the [Tabler bundle documentation](README.md) to find out more about using the theme.

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,6 +3,7 @@
 If you cannot find the needed information in this list of topics, please create an [issue](https://github.com/kevinpapst/TablerBundle/issues):
 
 * [Using the layout](layout.md)
+* [Error pages](error_pages.md)
 
 For the users migrating from the [AdminLTEBundle](https://github.com/kevinpapst/AdminLTEBundle):
 

--- a/docs/layout.md
+++ b/docs/layout.md
@@ -11,16 +11,30 @@ This bundle ships with two main template files which you can extend in your them
 
 **For all your admin pages**
 
-The default `layout.html.twig` can be used with:   
+The default `layout.html.twig` file can be used with:   
 ```
 {% extends '@Tabler/layout.html.twig' %}
 ```
 
 **For your security screens**
 
-The `security.html.twig` for login, register ... can be used with:   
+The `security.html.twig` file for login, register ... can be used with:   
 ```
 {% extends '@Tabler/security.html.twig' %}
+```
+
+**For your error pages**
+
+The `error.html.twig` for all of your [error pages](error_pages.md):   
+```
+{% extends '@Tabler/error.html.twig' %}
+```
+
+**For full width pages**
+
+The `fullpage.html.twig` file without header, menu, footer:   
+```
+{% extends '@Tabler/fullpage.html.twig' %}
 ```
 
 ## Twig Context-Helper

--- a/templates/error.html.twig
+++ b/templates/error.html.twig
@@ -1,21 +1,39 @@
-{#
-Use this as your error template page,
-use it by adding this code to your own error twig override:
-(e.g: https://symfony.com/doc/current/controller/error_pages.html)
+{% extends '@Tabler/fullpage.html.twig' %}
 
-{% extends '@Tabler/error.html.twig' %}
-#}
-
-{% extends '@Tabler/extends/layout_fullpage.html.twig' %}
+{% block title %}{{ status_text|trans({}, 'TablerBundle') }}{% endblock %}
 
 {% block page_content %}
+    {% set errorTitleKey = "http_error_#{status_code}.title" %}
+    {% set errorTitleTrans = errorTitleKey|trans({ '%status_code%': status_code }, 'exceptions') %}
+    {% if errorTitleKey == errorTitleTrans %}
+        {% set errorTitleKey = 'http_error.title' %}
+        {% set errorTitleTrans = errorTitleKey|trans({ '%status_code%': status_code }, 'exceptions') %}
+    {% endif %}
+
+    {% set errorMessageKey = "http_error_#{status_code}.description" %}
+    {% set errorMessageTrans = errorMessageKey|trans({ '%status_code%': status_code }, 'exceptions') %}
+    {% if errorMessageKey == errorMessageTrans %}
+        {% set errorMessageKey = 'http_error.description' %}
+        {% set errorMessageTrans = errorMessageKey|trans({ '%status_code%': status_code }, 'exceptions') %}
+    {% endif %}
+
     <div class="container-tight py-4">
         <div class="empty">
-            <div class="empty-header">{% block error_code %}500{% endblock %}</div>
-            <p class="empty-title">{% block error_title %}{{ 'Oops… You just found an error page'|trans({}, 'TablerBundle') }}{% endblock %}</p>
+            <div class="empty-header">{% block error_code %}{{ status_code }}{% endblock %}</div>
+            <p class="empty-title">
+                {% block error_title %}
+                    {% if errorTitleKey != errorTitleTrans %}
+                        {{ errorTitleTrans }}
+                    {% else %}
+                        {{ status_text }}
+                    {% endif %}
+                {% endblock %}
+            </p>
             <p class="empty-subtitle text-muted">
                 {% block error_subtitle %}
-                    {{ 'We are sorry but the page you are looking for was not found'|trans({}, 'TablerBundle') }}
+                    {% if errorMessageKey != errorMessageTrans %}
+                        {{ errorMessageTrans }}
+                    {% endif %}
                 {% endblock %}
             </p>
             <div class="empty-action">

--- a/templates/error.html.twig
+++ b/templates/error.html.twig
@@ -4,17 +4,17 @@
 
 {% block page_content %}
     {% set errorTitleKey = "http_error_#{status_code}.title" %}
-    {% set errorTitleTrans = errorTitleKey|trans({ '%status_code%': status_code }, 'exceptions') %}
+    {% set errorTitleTrans = errorTitleKey|trans({ '%status_code%': status_code }, 'TablerBundle') %}
     {% if errorTitleKey == errorTitleTrans %}
         {% set errorTitleKey = 'http_error.title' %}
-        {% set errorTitleTrans = errorTitleKey|trans({ '%status_code%': status_code }, 'exceptions') %}
+        {% set errorTitleTrans = errorTitleKey|trans({ '%status_code%': status_code }, 'TablerBundle') %}
     {% endif %}
 
     {% set errorMessageKey = "http_error_#{status_code}.description" %}
-    {% set errorMessageTrans = errorMessageKey|trans({ '%status_code%': status_code }, 'exceptions') %}
+    {% set errorMessageTrans = errorMessageKey|trans({ '%status_code%': status_code }, 'TablerBundle') %}
     {% if errorMessageKey == errorMessageTrans %}
         {% set errorMessageKey = 'http_error.description' %}
-        {% set errorMessageTrans = errorMessageKey|trans({ '%status_code%': status_code }, 'exceptions') %}
+        {% set errorMessageTrans = errorMessageKey|trans({ '%status_code%': status_code }, 'TablerBundle') %}
     {% endif %}
 
     <div class="container-tight py-4">

--- a/templates/error.html.twig
+++ b/templates/error.html.twig
@@ -1,0 +1,31 @@
+{#
+Use this as your error template page,
+use it by adding this code to your own error twig override:
+(e.g: https://symfony.com/doc/current/controller/error_pages.html)
+
+{% extends '@Tabler/error.html.twig' %}
+#}
+
+{% extends '@Tabler/extends/layout_fullpage.html.twig' %}
+
+{% block page_content %}
+    <div class="container-tight py-4">
+        <div class="empty">
+            <div class="empty-header">{% block error_code %}500{% endblock %}</div>
+            <p class="empty-title">{% block error_title %}{{ 'Oops… You just found an error page'|trans({}, 'TablerBundle') }}{% endblock %}</p>
+            <p class="empty-subtitle text-muted">
+                {% block error_subtitle %}
+                    {{ 'We are sorry but the page you are looking for was not found'|trans({}, 'TablerBundle') }}
+                {% endblock %}
+            </p>
+            <div class="empty-action">
+                {% block error_actions %}
+                    <a href="/" class="btn btn-primary">
+                        {{ tabler_icon('back') }}
+                        {{ 'Take me home'|trans({}, 'TablerBundle') }}
+                    </a>
+                {% endblock %}
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/templates/extends/layout_fullpage.html.twig
+++ b/templates/extends/layout_fullpage.html.twig
@@ -1,0 +1,37 @@
+{#
+This template is only for simple full-page rendering.
+{% extends '@Tabler/extends/layout_fullpage.html.twig' %}
+
+WARNING:
+If you want to render 'menu', 'nav', ...
+You should use 'layout.html.twig' instead :
+{% extends '@Tabler/layout.html.twig' %}
+
+#}
+<!doctype html{% block html_start %}{% endblock %}>
+<html lang="{{ app.request.locale }}">
+<head>
+    {% block head %}
+        <meta charset="utf-8"/>
+        <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover"/>
+        <meta http-equiv="X-UA-Compatible" content="ie=edge"/>
+    {% endblock %}
+    <title>{% block title %}{{ 'Error'|trans({}, 'TablerBundle') }}{% endblock %}</title>
+    {% block stylesheets %}
+        <link rel="stylesheet" href="{{ asset('bundles/tabler/tabler.css') }}">
+    {% endblock %}
+</head>
+<body{% block body_start %}{% endblock %} class="d-flex flex-column {{ 'border-top-wide border-primary theme-light'|tabler_body }}">
+{% block after_body_start %}{% endblock %}
+
+<div class="page page-center">
+    {% block page_content %}{% endblock %}
+</div>
+
+
+{% block javascripts %}
+    <script src="{{ asset('bundles/tabler/tabler.js') }}"></script>
+{% endblock %}
+
+</body>
+</html>

--- a/templates/fullpage.html.twig
+++ b/templates/fullpage.html.twig
@@ -1,13 +1,3 @@
-{#
-This template is only for simple full-page rendering.
-{% extends '@Tabler/extends/layout_fullpage.html.twig' %}
-
-WARNING:
-If you want to render 'menu', 'nav', ...
-You should use 'layout.html.twig' instead :
-{% extends '@Tabler/layout.html.twig' %}
-
-#}
 <!doctype html{% block html_start %}{% endblock %}>
 <html lang="{{ app.request.locale }}">
 <head>
@@ -16,7 +6,7 @@ You should use 'layout.html.twig' instead :
         <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover"/>
         <meta http-equiv="X-UA-Compatible" content="ie=edge"/>
     {% endblock %}
-    <title>{% block title %}{{ 'Error'|trans({}, 'TablerBundle') }}{% endblock %}</title>
+    <title>{% block title %}{% endblock %}</title>
     {% block stylesheets %}
         <link rel="stylesheet" href="{{ asset('bundles/tabler/tabler.css') }}">
     {% endblock %}
@@ -28,10 +18,8 @@ You should use 'layout.html.twig' instead :
     {% block page_content %}{% endblock %}
 </div>
 
-
 {% block javascripts %}
     <script src="{{ asset('bundles/tabler/tabler.js') }}"></script>
 {% endblock %}
-
 </body>
 </html>

--- a/translations/TablerBundle.de.xliff
+++ b/translations/TablerBundle.de.xliff
@@ -106,6 +106,18 @@
                 <source>Close modal</source>
                 <target>Schließen</target>
             </trans-unit>
+            <trans-unit resname="http_error.title" id="Oops… You just found an error">
+                <source>Oops… You just found an error</source>
+                <target>Uups… Du bist auf einen Fehler gestoßen</target>
+            </trans-unit>
+            <trans-unit resname="http_error.description" id="We are sorry but something went wrong">
+                <source>We are sorry but something went wrong</source>
+                <target>Es tut uns leid, aber etwas ist schief gegangen</target>
+            </trans-unit>
+            <trans-unit id="Take me home">
+                <source>Take me home</source>
+                <target>Zurück zum Anfang</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/translations/TablerBundle.en.xliff
+++ b/translations/TablerBundle.en.xliff
@@ -106,13 +106,13 @@
                 <source>Close modal</source>
                 <target>Close modal</target>
             </trans-unit>
-            <trans-unit id="Oops… You just found an error page">
-                <source>Oops… You just found an error page</source>
-                <target>Oops… You just found an error page</target>
+            <trans-unit resname="http_error.title" id="Oops… You just found an error">
+                <source>Oops… You just found an error</source>
+                <target>Oops… You just found an error</target>
             </trans-unit>
-            <trans-unit id="We are sorry but the page you are looking for was not found">
-                <source>We are sorry but the page you are looking for was not found</source>
-                <target>We are sorry but the page you are looking for was not found</target>
+            <trans-unit resname="http_error.description" id="We are sorry but something went wrong">
+                <source>We are sorry but something went wrong</source>
+                <target>We are sorry but something went wrong</target>
             </trans-unit>
             <trans-unit id="Take me home">
                 <source>Take me home</source>

--- a/translations/TablerBundle.en.xliff
+++ b/translations/TablerBundle.en.xliff
@@ -106,6 +106,18 @@
                 <source>Close modal</source>
                 <target>Close modal</target>
             </trans-unit>
+            <trans-unit id="Oops… You just found an error page">
+                <source>Oops… You just found an error page</source>
+                <target>Oops… You just found an error page</target>
+            </trans-unit>
+            <trans-unit id="We are sorry but the page you are looking for was not found">
+                <source>We are sorry but the page you are looking for was not found</source>
+                <target>We are sorry but the page you are looking for was not found</target>
+            </trans-unit>
+            <trans-unit id="Take me home">
+                <source>Take me home</source>
+                <target>Take me home</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/translations/TablerBundle.fr.xliff
+++ b/translations/TablerBundle.fr.xliff
@@ -94,12 +94,12 @@
                 <source>registration.confirmed</source>
                 <target>Félicitations %username%, votre compte est maintenant activé.</target>
             </trans-unit>
-            <trans-unit id="Oops… You just found an error page">
-                <source>Oops… You just found an error page</source>
+            <trans-unit resname="http_error.title" id="Oops… You just found an error">
+                <source>Oops… You just found an error</source>
                 <target>Oups… Vous avez trouvé une page d'erreur</target>
             </trans-unit>
-            <trans-unit id="We are sorry but the page you are looking for was not found">
-                <source>We are sorry but the page you are looking for was not found</source>
+            <trans-unit resname="http_error.description" id="We are sorry but something went wrong">
+                <source>We are sorry but something went wrong</source>
                 <target>Nous sommes désolé, mais la page que vous cherchez n'a pas été trouvée</target>
             </trans-unit>
             <trans-unit id="Take me home">

--- a/translations/TablerBundle.fr.xliff
+++ b/translations/TablerBundle.fr.xliff
@@ -100,7 +100,7 @@
             </trans-unit>
             <trans-unit resname="http_error.description" id="We are sorry but something went wrong">
                 <source>We are sorry but something went wrong</source>
-                <target>Nous sommes désolé, mais la page que vous cherchez n'a pas été trouvée</target>
+                <target>Nous sommes désolés mais quelque chose s'est mal passé</target>
             </trans-unit>
             <trans-unit id="Take me home">
                 <source>Take me home</source>

--- a/translations/TablerBundle.fr.xliff
+++ b/translations/TablerBundle.fr.xliff
@@ -94,6 +94,18 @@
                 <source>registration.confirmed</source>
                 <target>Félicitations %username%, votre compte est maintenant activé.</target>
             </trans-unit>
+            <trans-unit id="Oops… You just found an error page">
+                <source>Oops… You just found an error page</source>
+                <target>Oups… Vous avez trouvé une page d'erreur</target>
+            </trans-unit>
+            <trans-unit id="We are sorry but the page you are looking for was not found">
+                <source>We are sorry but the page you are looking for was not found</source>
+                <target>Nous sommes désolé, mais la page que vous cherchez n'a pas été trouvée</target>
+            </trans-unit>
+            <trans-unit id="Take me home">
+                <source>Take me home</source>
+                <target>Retourner au début</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>


### PR DESCRIPTION
## Description
Add `error` layout page.

404: `/_error/404.html`
![image](https://user-images.githubusercontent.com/25293190/147951935-b7ac1619-e982-4d12-a39f-4b6d180501bd.png)

500: `/_error/500.html`
![image](https://user-images.githubusercontent.com/25293190/147951978-5ccce529-4bd1-450e-aa8f-1c448309531a.png)


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] I updated the documentation (see [here](https://github.com/kevinpapst/TablerBundle/tree/master/docs))
- [x] I agree that this code will be published under the [MIT license](https://github.com/kevinpapst/TablerBundle/blob/master/LICENSE)
