### PR TITLE
[Feature] Add TWIG submit_button() macro

### DIFF
--- a/templates/components/button.html.twig
+++ b/templates/components/button.html.twig
@@ -23,7 +23,7 @@
         {% set forceTitle = values.combined ?? false %}
         {% set label = values.label ?? null %}
         {% set translation_domain = values.translation_domain ?? 'messages' %}
-        {% set buttonType = values.buttonType == 'button' or values.buttonType == 'submit' ? 'button' : 'a' %}
+        {% set buttonType = values.buttonType is defined and (values.buttonType == 'button' or values.buttonType == 'submit') ? 'button' : 'a' %}
 
         {% if type != 'link' and not forceTitle and type is not same as (false) and label is null %}
             {% set class = class ~ ' btn-icon' %}
@@ -33,7 +33,7 @@
             {% set class = class ~ " disabled"  %}
         {% endif %}
 
-        <{{ buttonType|raw }} class="{{ class | trim }}" {% if buttonType not same as ("button") %}href="{{ url }}"{% endif %}
+        <{{ buttonType|raw }} class="{{ class | trim }}" {% if buttonType is not same as ("button") %}href="{{ url }}"{% endif %}
                 {%- if disabled is same as (true) %} disabled="disabled"{% endif %}
                 {%- if id is not empty %} id="{{ id }}"{% endif %}
                 {%- if toggle is not empty %} data-bs-toggle="{{ toggle }}"{% endif %}

--- a/templates/components/button.html.twig
+++ b/templates/components/button.html.twig
@@ -23,6 +23,7 @@
         {% set forceTitle = values.combined ?? false %}
         {% set label = values.label ?? null %}
         {% set translation_domain = values.translation_domain ?? 'messages' %}
+        {% set isHtmlButton = values.isHtmlButton ?? false %}
 
         {% if type != 'link' and not forceTitle and type is not same as (false) and label is null %}
             {% set class = class ~ ' btn-icon' %}
@@ -32,7 +33,7 @@
             {% set class = class ~ " disabled"  %}
         {% endif %}
 
-        <a class="{{ class | trim }}" href="{{ url }}"
+        <{% if isHtmlButton %}button{% else %}a{% endif %} class="{{ class | trim }}" {% if not isHtmlButton %}href="{{ url }}"{% endif %}
                 {%- if disabled is same as (true) %} disabled="disabled"{% endif %}
                 {%- if id is not empty %} id="{{ id }}"{% endif %}
                 {%- if toggle is not empty %} data-bs-toggle="{{ toggle }}"{% endif %}
@@ -57,6 +58,6 @@
             {%- if label is not null -%}
                 <span class="badge bg-yellow">{{ label }}</span>
             {%- endif -%}
-        </a>
+        </{% if isHtmlButton %}button{% else %}a{% endif %}>
     {% endapply %}
 {% endmacro %}

--- a/templates/components/button.html.twig
+++ b/templates/components/button.html.twig
@@ -23,7 +23,7 @@
         {% set forceTitle = values.combined ?? false %}
         {% set label = values.label ?? null %}
         {% set translation_domain = values.translation_domain ?? 'messages' %}
-        {% set isHtmlButton = values.isHtmlButton ?? false %}
+        {% set buttonType = values.buttonType == 'button' or values.buttonType == 'submit' ? 'button' : 'a' %}
 
         {% if type != 'link' and not forceTitle and type is not same as (false) and label is null %}
             {% set class = class ~ ' btn-icon' %}
@@ -33,14 +33,14 @@
             {% set class = class ~ " disabled"  %}
         {% endif %}
 
-        <{% if isHtmlButton %}button{% else %}a{% endif %} class="{{ class | trim }}" {% if not isHtmlButton %}href="{{ url }}"{% endif %}
+        <{{ buttonType|raw }} class="{{ class | trim }}" {% if buttonType not same as ("button") %}href="{{ url }}"{% endif %}
                 {%- if disabled is same as (true) %} disabled="disabled"{% endif %}
                 {%- if id is not empty %} id="{{ id }}"{% endif %}
                 {%- if toggle is not empty %} data-bs-toggle="{{ toggle }}"{% endif %}
                 {%- if modal is not empty %} data-bs-toggle="modal" data-bs-target="{{ modal }}"{% endif %}
                 {%- if collapse is not empty %} data-bs-toggle="collapse" data-bs-target="{{ collapse }}"{% endif %}
                 {%- if onclick is not empty %} onclick="{{ onclick }}"{% endif %}
-                {%- if target is not empty %} target="{{ target }}"{% endif %}
+                {%- if target is not empty %} {% if values.buttonType == 'submit' %}formtarget{% else %}target{% endif %}="{{ target }}"{% endif %}
                 {%- if not forceTitle and title is not null and type is not same as (false) %} data-toggle="tooltip" data-bs-placement="top" title="{{ title|trans({}, translation_domain) }}"{% endif %}
                 {%- if attr is not empty %}
                     {% for name, value in attr %}
@@ -58,6 +58,6 @@
             {%- if label is not null -%}
                 <span class="badge bg-yellow">{{ label }}</span>
             {%- endif -%}
-        </{% if isHtmlButton %}button{% else %}a{% endif %}>
+        </{{ buttonType|raw }}>
     {% endapply %}
 {% endmacro %}

--- a/templates/components/buttons.html.twig
+++ b/templates/components/buttons.html.twig
@@ -48,7 +48,7 @@
         combined : true,
         attr : {type: 'submit'},
         disabled : false,
-        isHtmlButton : true,
+        buttonType : 'submit',
     } %}
 
     {% set values_attr = default_values.attr | merge(user_values.attr|default({})) %}

--- a/templates/components/buttons.html.twig
+++ b/templates/components/buttons.html.twig
@@ -40,3 +40,20 @@
         {% endif %}
     </button>
 {% endmacro %}
+
+{% macro submit_button(icon, user_values, type) %}
+    {% import '@Tabler/components/button.html.twig' as macro %}
+
+    {% set default_values = {
+        combined : true,
+        attr : {type: 'submit'},
+        disabled : false,
+        isHtmlButton : true,
+    } %}
+
+    {% set values_attr = default_values.attr | merge(user_values.attr|default({})) %}
+    {% set values = default_values | merge(user_values|default({})) %}
+    {% set values = values | merge({'attr' : values_attr}) %}
+
+    {{ macro.button(icon, values, type) }}
+{% endmacro %}


### PR DESCRIPTION
## Description

According to https://github.com/kevinpapst/TablerBundle/issues/27

Add macro to create real button submit from button macro.

Example:
```twig
{{ submit_button("save", {
    title : 'action.save'|trans,
    attr: {
       'data-text' : 'test',
       'data-loading-text' : 'action.saving'|trans ~ '...',
    }
}, 'success') }}
```

HTML result:
```html
<button class="btn btn-success" type="submit" data-text="test" data-loading-text="action.saving...">
   <i class="icon fas fa-save"></i>
   Enregistrer
</button>
```
![image](https://user-images.githubusercontent.com/25293190/148028755-a8c4db64-af64-4ca3-8cee-7701c8b6c88b.png)


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] I updated the documentation (see [here](https://github.com/kevinpapst/TablerBundle/tree/master/docs))
- [x] I agree that this code will be published under the [MIT license](https://github.com/kevinpapst/TablerBundle/blob/master/LICENSE)
