### PR TITLE
[BugFix] Reorder blocks to match breadcrumb from Tabler.io doc

### DIFF
--- a/templates/layout.html.twig
+++ b/templates/layout.html.twig
@@ -82,9 +82,11 @@ Enjoy your theme!
             <div class="page-header d-print-none">
                 <div class="row align-items-center">
                     <div class="col">
+                        {% block breadcrumb %}
                         <div class="page-pretitle">
-                            {% block page_pretitle %}{% block breadcrumb %}Overview{% endblock %}{% endblock %}
+                            {% block page_pretitle %}Overview{% endblock %}
                         </div>
+                        {% endblock %}
                         <h2 class="page-title">
                             {% block page_title %}Dashboard{% endblock %}
                         </h2>

--- a/templates/layout.html.twig
+++ b/templates/layout.html.twig
@@ -83,19 +83,19 @@ Enjoy your theme!
                 <div class="row align-items-center">
                     <div class="col">
                         <div class="page-pretitle">
-                            {% block page_subtitle %}Overview{% endblock %}
+                            {% block page_pretitle %}{% block breadcrumb %}Overview{% endblock %}{% endblock %}
                         </div>
                         <h2 class="page-title">
                             {% block page_title %}Dashboard{% endblock %}
                         </h2>
-                        {% block page_stats %}
+                        {% block page_stats %}{% block page_subtitle %}
                         <div class="text-muted mt-1">
                             1-10 of 100
                         </div>
-                        {% endblock %}
+                        {% endblock %}{% endblock %}
                     </div>
                     <div class="col-auto ms-auto d-print-none">
-                        {% block breadcrumb %}
+                        {% block page_header_actions %}
                         <div class="btn-list">
                             <a href="#" class="btn btn-white">
                               New view

--- a/templates/layout.html.twig
+++ b/templates/layout.html.twig
@@ -90,7 +90,7 @@ Enjoy your theme!
                         <h2 class="page-title">
                             {% block page_title %}Dashboard{% endblock %}
                         </h2>
-                        {% block page_stats %}{% block page_subtitle %}
+                        {% block page_subtitle %}
                         <div class="text-muted mt-1">
                             1-10 of 100
                         </div>

--- a/templates/layout.html.twig
+++ b/templates/layout.html.twig
@@ -94,7 +94,7 @@ Enjoy your theme!
                         <div class="text-muted mt-1">
                             1-10 of 100
                         </div>
-                        {% endblock %}{% endblock %}
+                        {% endblock %}
                     </div>
                     <div class="col-auto ms-auto d-print-none">
                         {% block page_actions %}

--- a/templates/layout.html.twig
+++ b/templates/layout.html.twig
@@ -97,7 +97,7 @@ Enjoy your theme!
                         {% endblock %}{% endblock %}
                     </div>
                     <div class="col-auto ms-auto d-print-none">
-                        {% block page_header_actions %}
+                        {% block page_actions %}
                         <div class="btn-list">
                             <a href="#" class="btn btn-white">
                               New view


### PR DESCRIPTION
## Description
According to #19 & #21

Renaming blocks for breadcrumb.

From:
![image](https://user-images.githubusercontent.com/25293190/148033970-95c39f82-052c-414f-b426-b6f136a04440.png)
To:
![image](https://user-images.githubusercontent.com/25293190/148033822-30134a8b-e38e-4d31-9548-55c0ea7444de.png)

---------------

From:
![image](https://user-images.githubusercontent.com/25293190/148034017-360ead78-4ce0-41dc-b31e-d074df63b10f.png)
To:
![image](https://user-images.githubusercontent.com/25293190/148033845-ea6a8ab1-ad86-427a-a6f6-16b06df4039f.png)


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] I updated the documentation (see [here](https://github.com/kevinpapst/TablerBundle/tree/master/docs))
- [x] I agree that this code will be published under the [MIT license](https://github.com/kevinpapst/TablerBundle/blob/master/LICENSE)
