### PR TITLE
Added remember me block to security.html.twig for more flexibility

### DIFF
--- a/templates/security.html.twig
+++ b/templates/security.html.twig
@@ -56,12 +56,14 @@
                                 #}
                             </div>
                         </div>
+                        {% block remember_me %}
                         <div class="mb-3">
                             <label class="form-check">
                                 <input id="remember_me" tabindex="30" name="_remember_me" type="checkbox" class="form-check-input">
                                 <span class="form-check-label">{{ 'Remember Me'|trans({}, 'TablerBundle') }}</span>
                             </label>
                         </div>
+                        {% endblock %}
                         <div class="form-footer">
                             <button type="submit" tabindex="40" class="btn btn-primary w-100">{{ 'Sign In'|trans({}, 'TablerBundle') }}</button>
                         </div>


### PR DESCRIPTION
## Description
Sometimes you don't want the remember me functionality and with this additional block you can remove it without copying the whole template file.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] I updated the documentation (see [here](https://github.com/kevinpapst/TablerBundle/tree/master/docs))
- [ ] I agree that this code will be published under the [MIT license](https://github.com/kevinpapst/TablerBundle/blob/master/LICENSE)
