### PR TITLE
BugFix tooltip when title displayed in raw HTML

### DIFF
--- a/templates/components/button.html.twig
+++ b/templates/components/button.html.twig
@@ -18,7 +18,7 @@
         {% set title = values.title ?? null %}
         {% set class = class ~ ( values.class | default("")) %}
         {% set attr = values.attr ?? {} %}
-        {% set forceTitle = values.combined ?? false %}
+        {% set forceTitle = icon is same as (false) or (values.combined ?? false) %}
         {% set badge = values.badge ?? (values.label ?? null) %}
         {% set badge_color = values.badgeColor ?? (values.labelColor ?? 'yellow') %}
         {% set translation_domain = values.translation_domain ?? 'messages' %}


### PR DESCRIPTION
## Description
Fix a bug when tooltip is displayed with HTML title in the same time without icon

### BEFORE
Hover on black button:
![image](https://user-images.githubusercontent.com/25293190/150761723-13800be1-5a01-4660-9eb7-b29f26a12562.png)

Hover on green button:
![image](https://user-images.githubusercontent.com/25293190/150761768-894dfb94-b6d3-46ea-996c-21c193964ed9.png)


### AFTER
Hover on black button:
![image](https://user-images.githubusercontent.com/25293190/150761829-49140cc2-9a5b-470e-9376-32829f27cf1f.png)

Hover on green button:
![image](https://user-images.githubusercontent.com/25293190/150761849-98f1f5ca-b848-4900-b450-5fe6f28c678f.png)

Hover on middle button:
![image](https://user-images.githubusercontent.com/25293190/150762015-ca20b720-13b9-4ca1-bdfc-0788798f4dec.png)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] I updated the documentation (see [here](https://github.com/kevinpapst/TablerBundle/tree/master/docs))
- [x] I agree that this code will be published under the [MIT license](https://github.com/kevinpapst/TablerBundle/blob/master/LICENSE)
