### PR TITLE
change argument order to simplify icon usage outside buttons

### DIFF
--- a/src/Twig/RuntimeExtension.php
+++ b/src/Twig/RuntimeExtension.php
@@ -123,13 +123,13 @@ final class RuntimeExtension implements RuntimeExtensionInterface
         return $userEvent;
     }
 
-    public function createIcon(string $name, bool $isButton = true, string $default = null): string
+    public function createIcon(string $name, bool $withIconClass = false, string $default = null): string
     {
-        return '<i class="' . $this->icon($name, $isButton, $default) . '"></i>';
+        return '<i class="' . $this->icon($name, $withIconClass, $default) . '"></i>';
     }
 
-    public function icon(string $name, bool $isButton = true, string $default = null): string
+    public function icon(string $name, bool $withIconClass = false, string $default = null): string
     {
-        return ($isButton ? 'icon ' : '') . ($this->icons[str_replace('-', '_', $name)] ?? ($default ?? $name));
+        return ($withIconClass ? 'icon ' : '') . ($this->icons[str_replace('-', '_', $name)] ?? ($default ?? $name));
     }
 }

--- a/src/Twig/RuntimeExtension.php
+++ b/src/Twig/RuntimeExtension.php
@@ -123,13 +123,13 @@ final class RuntimeExtension implements RuntimeExtensionInterface
         return $userEvent;
     }
 
-    public function createIcon(string $name, string $default = null, bool $isIcon = true): string
+    public function createIcon(string $name, bool $isButton = true, string $default = null): string
     {
-        return '<i class="' . $this->icon($name, $default, $isIcon) . '"></i>';
+        return '<i class="' . $this->icon($name, $isButton, $default) . '"></i>';
     }
 
-    public function icon(string $name, string $default = null, bool $isIcon = true): string
+    public function icon(string $name, bool $isButton = true, string $default = null): string
     {
-        return ($isIcon ? 'icon ' : '') . ($this->icons[str_replace('-', '_', $name)] ?? ($default ?? $name));
+        return ($isButton ? 'icon ' : '') . ($this->icons[str_replace('-', '_', $name)] ?? ($default ?? $name));
     }
 }

--- a/templates/components/alert.html.twig
+++ b/templates/components/alert.html.twig
@@ -5,7 +5,7 @@
         <div class="d-flex">
             {% if icon %}
                 <div>
-                    <i class="alert-icon {{ icon|icon(icon, false) }}"></i>
+                    <i class="alert-icon {{ icon|icon(icon) }}"></i>
                 </div>
             {% endif %}
             <div>

--- a/templates/components/button.html.twig
+++ b/templates/components/button.html.twig
@@ -52,7 +52,7 @@
             {% endfor %}
         {% endif %}>
         {%- if icon is not same as (false) -%}
-            {{ tabler_icon(icon) }}
+            {{ tabler_icon(icon, true, icon) }}
         {% endif %}
         {%- if (forceTitle or icon is same as (false)) and title is not null -%}
             {{ title|trans({}, translation_domain) }}

--- a/templates/components/buttons.html.twig
+++ b/templates/components/buttons.html.twig
@@ -7,20 +7,12 @@
     {{ _self.action_cardtoolbutton('collapse', {collapse: target, title: label|default('')}) }}
 {% endmacro %}
 
-{# TODO test me #}
-{% macro link_toolbutton(icon, href, label, attrs) %}
-    {% set attrs = attrs|default({})|merge({class: 'me-2 ' ~ (attrs.class|default(''))}) %}
-    <a href="{{ href }}" {% for name, value in attrs|default({}) %} {{ name }}="{{ value }}"{% endfor %}>
-        {{ tabler_icon(icon) }}{% if label is not null %} {{ label }}{% endif %}
-    </a>
-{% endmacro %}
-
 {% macro link_button(label, href, icon, type, size) %}
     {% set _size = size|default(null) %}
     {% set _type = type|default('primary') %}
     <a href="{{ href|default('#') }}" class="btn btn-{{ _type }}{% if _size %} btn-{{ _size }}{% endif %}">
         {% if icon %}
-            {{ tabler_icon(icon) }}
+            {{ tabler_icon(icon, true) }}
         {% endif %}
         {% if label %}
             <span>{{ label }}</span>
@@ -33,7 +25,7 @@
     {% set _type = type|default('primary') %}
     <button data-action="{{ action }}" class="btn btn-{{ _type }}{% if _size %} btn-{{ _size }}{% endif %}">
         {% if icon %}
-            {{ tabler_icon(icon) }}
+            {{ tabler_icon(icon, true) }}
         {% endif %}
         {% if label %}
             <span>{{ label }}</span>

--- a/templates/error.html.twig
+++ b/templates/error.html.twig
@@ -38,10 +38,8 @@
             </p>
             <div class="empty-action">
                 {% block error_actions %}
-                    <a href="{{ path('tabler_welcome'|tabler_route) }}" class="btn btn-primary">
-                        {{ tabler_icon('back') }}
-                        {{ 'Take me home'|trans({}, 'TablerBundle') }}
-                    </a>
+                    {% from '@Tabler/components/buttons.html.twig' import link_button %}
+                    {{ link_button(('Take me home'|trans({}, 'TablerBundle')), (path('tabler_welcome'|tabler_route)), 'back') }}
                 {% endblock %}
             </div>
         </div>

--- a/templates/includes/menu.html.twig
+++ b/templates/includes/menu.html.twig
@@ -12,7 +12,7 @@
                 {%- endif -%}>
                     {% if item.icon %}
                         <span class="nav-link-icon d-md-none d-lg-inline-block text-center">
-                            {{ tabler_icon(item.icon, null, false) }}
+                            {{ tabler_icon(item.icon, false, item.icon) }}
                         </span>
                     {% endif %}
                 <span class="nav-link-title">{{ item.label|trans }}</span>
@@ -32,7 +32,7 @@
                         <a class="dropdown-item {{ child.isActive ? 'active':'' }}" href="{{ '/' in child.route ? child.route : path(child.route|tabler_route, child.routeArgs) }}">
                             {% if child.icon %}
                                 <span class="nav-link-icon d-md-none d-lg-inline-block text-center">
-                                    {{ tabler_icon(child.icon, null, false) }}
+                                    {{ tabler_icon(child.icon, false, child.icon) }}
                                 </span>
                             {% endif %}
                             {{ child.label|trans }}

--- a/templates/security/password-reset.html.twig
+++ b/templates/security/password-reset.html.twig
@@ -13,10 +13,8 @@
             <input type="text" id="username" name="username" required="required" class="form-control" placeholder="{{ 'Username or email address'|trans({}, 'TablerBundle') }}">
         </div>
         <div class="form-footer">
-            <button type="submit" class="btn btn-primary w-100">
-                {{ tabler_icon('mail') }}
-                {{ 'Reset your password'|trans({}, 'TablerBundle') }}
-            </button>
+            {% from '@Tabler/components/buttons.html.twig' import submit_button %}
+            {{ submit_button('mail', {class: 'w-100', title: 'Reset your password', translation_domain: 'TablerBundle'}, 'primary') }}
         </div>
     </form>
 {% endblock %}


### PR DESCRIPTION
## Description

Attention: This can a BC break if you used more than an argument in the `|icon` filter or more than one argument in the `tabler_icon()` function before.

Fixes #68  

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] I updated the documentation (see [here](https://github.com/kevinpapst/TablerBundle/tree/master/docs))
- [x] I agree that this code will be published under the [MIT license](https://github.com/kevinpapst/TablerBundle/blob/master/LICENSE)
