### PR TITLE
Add `status indicator` component

### DIFF
--- a/templates/components/status_indicator.html.twig
+++ b/templates/components/status_indicator.html.twig
@@ -1,0 +1,13 @@
+{% macro status_indicator(options) %}
+
+    {% set _color = options.color ?? 'green' %}
+    {% set _animated = options.animated ?? true %}
+    {% set _extraClass = options.extraClass ?? '' %}
+
+    <span class="status-indicator {{ _animated ? 'status-indicator-animated' : '' }} {{ 'status-'~_color }} {{ _extraClass }}">
+      <span class="status-indicator-circle"></span>
+      <span class="status-indicator-circle"></span>
+      <span class="status-indicator-circle"></span>
+    </span>
+
+{% endmacro %}


### PR DESCRIPTION
See https://preview.tabler.io/docs/statuses.html#status-indicator
#### Usage

```twig
{% from '@Tabler/components/status_indicator.html.twig' import status_indicator %}

<div class="row align-items-center text-start">
    <div class="col p-0">
        {{ status_indicator({color : item.open ? 'green' : 'red', animated : false, extraClass :'float-end' }) }}
    </div>
    <div class="col p-0">
        {{ item.open ? 'label.opened'|trans : 'label.closed'|trans }}
    </div>
</div>
```

#### Preview
![image](https://user-images.githubusercontent.com/25293190/169996450-d8ed21aa-9606-45d9-a5c9-e85632867752.png)



## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] I updated the documentation (see [here](https://github.com/kevinpapst/TablerBundle/tree/master/docs))
- [x] I agree that this code will be published under the [MIT license](https://github.com/kevinpapst/TablerBundle/blob/master/LICENSE)
