### PR TITLE
Refactoring `alert()` macro

### DIFF
--- a/templates/components/alert.html.twig
+++ b/templates/components/alert.html.twig
@@ -37,10 +37,10 @@
             {% if _title is not empty or _description is not empty %}
                 <div>
                     {% if _title is not empty %}
-                        <h3 class="{{ _description is not empty ? 'mb-1' : 'mb-0' }}">{{ _title }}</h3>
+                        <h3 class="{{ _description is not empty ? 'mb-1' : 'mb-0' }}">{{ _title|raw }}</h3>
                     {% endif %}
                     {% if _description is not empty %}
-                        <p class="m-0">{{ _description }}</p>
+                        <p class="m-0">{{ _description|raw }}</p>
                     {% endif %}
                 </div>
             {% endif %}

--- a/templates/components/alert.html.twig
+++ b/templates/components/alert.html.twig
@@ -9,8 +9,7 @@
         {% set _icon = options.icon ?? null %}
         {% set _dismissible = (options.dismissible ?? false) is same as (true) %}
         {% set _important = (options.important ?? false) is same as (true) %}
-
-        {% set _background = _title is empty or _description is empty or _important %}
+        {% set _raw = (options.raw ?? false) is same as (true) %}
     {% else %}
         {% deprecated "Passing multiple parameters to 'alert()' Tabler macro is deprecated, use options object syntax." %}
 
@@ -19,9 +18,11 @@
         {% set _description = description is defined ? description|trans : null %}
         {% set _icon = icon ?? null %}
         {% set _dismissible = (dismissible ?? false) is same as (true) %}
-
-        {% set _background = _title is empty or _description is empty %}
+        {% set _important = false %}
+        {% set _raw = false %}
     {% endif %}
+
+    {% set _background = _title is empty or _description is empty or _important %}
 
     <div
             class="alert alert-{{ _type }} {% if _dismissible %}alert-dismissible{% endif %} {% if _background %}alert-important{% endif %}"
@@ -37,10 +38,10 @@
             {% if _title is not empty or _description is not empty %}
                 <div>
                     {% if _title is not empty %}
-                        <h3 class="{{ _description is not empty ? 'mb-1' : 'mb-0' }}">{{ _title|raw }}</h3>
+                        <h3 class="{{ _description is not empty ? 'mb-1' : 'mb-0' }}">{{ _raw ? _title|raw : _title }}</h3>
                     {% endif %}
                     {% if _description is not empty %}
-                        <p class="m-0">{{ _description|raw }}</p>
+                        <p class="m-0">{{ _raw ? _description|raw : _description }}</p>
                     {% endif %}
                 </div>
             {% endif %}

--- a/templates/components/alert.html.twig
+++ b/templates/components/alert.html.twig
@@ -1,27 +1,51 @@
 {% macro alert(type, description, title, icon, dismissible) %}
-    {% set dismissible = dismissible is same as (true) ? true : false %}
-    {% set background = title is empty or description is empty ? true : false %}
-    <div class="alert alert-{{ type|default('danger') }}{% if dismissible %} alert-dismissible{% endif %}{% if background %} alert-important{% endif %}" role="alert">
+
+    {% if type is iterable %}
+        {% set options = type %}
+
+        {% set _type = options.type ?? 'danger' %}
+        {% set _title = options.title ?? null %}
+        {% set _description = options.description ?? null %}
+        {% set _icon = options.icon ?? null %}
+        {% set _dismissible = (options.dismissible ?? false) is same as (true) %}
+        {% set _important = (options.important ?? false) is same as (true) %}
+
+        {% set _background = _title is empty or _description is empty or _important %}
+    {% else %}
+        {% deprecated "Passing multiple parameters to 'alert()' Tabler macro is deprecated, use options object syntax." %}
+
+        {% set _type = type ?? 'danger' %}
+        {% set _title = title is defined ? title|trans : null %}
+        {% set _description = description is defined ? description|trans : null %}
+        {% set _icon = icon ?? null %}
+        {% set _dismissible = (dismissible ?? false) is same as (true) %}
+
+        {% set _background = _title is empty or _description is empty %}
+    {% endif %}
+
+    <div
+            class="alert alert-{{ _type }} {% if _dismissible %}alert-dismissible{% endif %} {% if _background %}alert-important{% endif %}"
+            role="alert"
+    >
         <div class="d-flex">
-            {% if icon %}
-                <div>
-                    <i class="{% if background %}icon{% else %}alert-icon{% endif%} {{ icon|tabler_icon(false, icon) }}"></i>
+            {% if _icon %}
+                <div class="alert-icon">
+                    {{ tabler_icon(_icon, true) }}
                 </div>
             {% endif %}
-            {% if icon or not background %}<div>{% endif %}
-                {% if background %}
-                    {{ title|trans }}
-                    {{ description|trans }}
-                {% elseif title is not empty and description is not empty %}
-                    <h4 class="alert-title">{{ title|trans }}</h4>
-                    <div class="text-muted">{{ description|trans }}</div>
-                {% elseif title is not empty %}
-                    <h4 class="alert-title">{{ title|trans }}</h4>
-                {% elseif description is not empty %}
-                    {{ description|trans }}
-                {% endif %}
-            {% if icon or not background %}</div>{% endif %}
+
+            {% if _title is not empty or _description is not empty %}
+                <div>
+                    {% if _title is not empty %}
+                        <h3 class="{{ _description is not empty ? 'mb-1' : 'mb-0' }}">{{ _title }}</h3>
+                    {% endif %}
+                    {% if _description is not empty %}
+                        <p class="m-0">{{ _description }}</p>
+                    {% endif %}
+                </div>
+            {% endif %}
         </div>
-        {% if dismissible %}<a class="btn-close" data-bs-dismiss="alert" aria-label="close"></a>{% endif %}
+
+        {% if _dismissible %}<a class="btn-close" data-bs-dismiss="alert" aria-label="close"></a>{% endif %}
     </div>
 {% endmacro %}


### PR DESCRIPTION
## Description
Related to #89 

#### Usage

```twig
{% from '@Tabler/components/alert.html.twig' import alert %}

<div class="row">
    <div class="col-6">
        {{ alert('danger', 'Description' ,'Title', 'fas fa-exclamation-triangle', true) }}
        {{ alert('danger', 'Description' ,'Title', 'fas fa-exclamation-triangle') }}
        {{ alert('danger', 'Description' ,'Title', 'fas fa-exclamation-triangle') }} {# Error here #}
        {{ alert('warning', 'Description' ,'Title') }}
        {{ alert('warning', null ,'Title') }}
        {{ alert('warning', null ,'Title', 'fas fa-exclamation-triangle') }}
        {{ alert('success', 'Description') }}
        {{ alert('success', 'Description', null, 'fas fa-exclamation-triangle') }}
        {{ alert('primary') }}
    </div>

    <div class="col-6">
        {{ alert({title : 'Title V2', description: 'Description V2', icon : 'warning', dismissible : true}) }}
        {{ alert({title : 'Title V2', description: 'Description V2', icon : 'warning'}) }}
        {{ alert({title : 'Title V2', description: 'Description V2', icon : 'warning', important: true}) }} {# Looks good now #}
        {{ alert({title : 'Title V2', description: 'Description V2', type : 'warning'}) }}
        {{ alert({title : 'Title V2', type : 'warning'}) }}
        {{ alert({title : 'Title V2', icon : 'warning', type : 'warning'}) }}
        {{ alert({description : 'Description V2', type : 'success'}) }}
        {{ alert({description : 'Description V2', type : 'success', icon : 'warning'}) }}
        {{ alert({type : 'primary'}) }}
    </div>
</div>
```

#### Preview

![image](https://user-images.githubusercontent.com/25293190/171182002-d9f9c998-59d5-4959-9f8a-4e16d9fd073e.png)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] I updated the documentation (see [here](https://github.com/kevinpapst/TablerBundle/tree/master/docs))
- [x] I agree that this code will be published under the [MIT license](https://github.com/kevinpapst/TablerBundle/blob/master/LICENSE)
