### PR TITLE
BugFix Alert text style without `alert-important`

### DIFF
--- a/templates/components/alert.html.twig
+++ b/templates/components/alert.html.twig
@@ -38,10 +38,18 @@
             {% if _title is not empty or _description is not empty %}
                 <div>
                     {% if _title is not empty %}
-                        <h3 class="{{ _description is not empty ? 'mb-1' : 'mb-0' }}">{{ _raw ? _title|raw : _title }}</h3>
+                        {% if _background %}
+                            <h3 class="{{ _description is not empty ? 'mb-1' : 'mb-0' }}">{{ _raw ? _title|raw : _title }}</h3>
+                        {% else %}
+                            <h4 class="alert-title">{{ _raw ? _title|raw : _title }}</h4>
+                        {% endif %}
                     {% endif %}
                     {% if _description is not empty %}
-                        <p class="m-0">{{ _raw ? _description|raw : _description }}</p>
+                        {% if _background %}
+                            <p class="m-0">{{ _raw ? _description|raw : _description }}</p>
+                        {% else %}
+                            <div class="text-muted">{{ _raw ? _description|raw : _description }}</div>
+                        {% endif %}
                     {% endif %}
                 </div>
             {% endif %}

--- a/templates/components/alert.html.twig
+++ b/templates/components/alert.html.twig
@@ -39,7 +39,7 @@
                 <div>
                     {% if _title is not empty %}
                         {% if _background %}
-                            <h3 class="{{ _description is not empty ? 'mb-1' : 'mb-0' }}">{{ _raw ? _title|raw : _title }}</h3>
+                            <h4 class="{{ _description is not empty ? 'mb-1' : 'mb-0' }}">{{ _raw ? _title|raw : _title }}</h4>
                         {% else %}
                             <h4 class="alert-title">{{ _raw ? _title|raw : _title }}</h4>
                         {% endif %}


### PR DESCRIPTION
## Description
Fix of https://github.com/kevinpapst/TablerBundle/pull/90

![image](https://user-images.githubusercontent.com/25293190/171809623-17a733cf-2e1a-40b8-a046-436e44fd4326.png)


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] I updated the documentation (see [here](https://github.com/kevinpapst/TablerBundle/tree/master/docs))
- [x] I agree that this code will be published under the [MIT license](https://github.com/kevinpapst/TablerBundle/blob/master/LICENSE)
