### PR TITLE
Cleanup FOS user references

### DIFF
--- a/src/Model/UserInterface.php
+++ b/src/Model/UserInterface.php
@@ -15,6 +15,7 @@ interface UserInterface
      * The user identifier for generating links.
      *
      * @return string
+     * @deprecated will be renamed to getUserIdentifier() once we raise the minimum SF version to 5
      */
     public function getIdentifier(): string;
 
@@ -33,8 +34,11 @@ interface UserInterface
     public function getTitle(): ?string;
 
     /**
-     * URL to the user avatar.
-     * Can be something else if you overwrite the avatar component.
+     * UReturns the URL to the user avatar or null if none is available.
+     *
+     * You can change the avatar behaviour and return any other string,
+     * you just need to overwrite the avatar component at templates/components/avatar_image.html.twig
+     *
      * @return string|null
      */
     public function getAvatar(): ?string;

--- a/src/Model/UserInterface.php
+++ b/src/Model/UserInterface.php
@@ -34,10 +34,10 @@ interface UserInterface
     public function getTitle(): ?string;
 
     /**
-     * UReturns the URL to the user avatar or null if none is available.
+     * Returns the URL to the user avatar or null if none is available.
      *
-     * You can change the avatar behaviour and return any other string,
-     * you just need to overwrite the avatar component at templates/components/avatar_image.html.twig
+     * You can change the avatar behaviour and return any other string, you just need
+     * to overwrite the avatar component at templates/components/avatar_image.html.twig.
      *
      * @return string|null
      */

--- a/templates/security.html.twig
+++ b/templates/security.html.twig
@@ -32,7 +32,7 @@
                     {% endif %}
                 {% endblock %}
                 {% block login_form %}
-                    <form action="{{ path('tabler_login_check'|tabler_route) }}" method="post" autocomplete="off" class="login-box-body">
+                    <form action="{{ path('tabler_login_check'|tabler_route) }}" method="post" autocomplete="off" class="login-box-body security-login">
                     {% block login_form_start %}{% endblock %}
                         <div class="mb-3">
                             <label class="form-label">{{ 'Username'|trans({}, 'TablerBundle') }}</label>
@@ -51,13 +51,6 @@
                             </label>
                             <div class="input-group input-group-flat">
                                 <input name="_password" type="password" tabindex="20" class="form-control" placeholder="{{ 'Password'|trans({}, 'TablerBundle') }}">
-                                {#
-                                <span class="input-group-text">
-                                  <a href="#" class="link-secondary" title="Show password" data-bs-toggle="tooltip"><!-- Download SVG icon from http://tabler-icons.io/i/eye -->
-                                    <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><circle cx="12" cy="12" r="2" /><path d="M22 12c-2.667 4.667 -6 7 -10 7s-7.333 -2.333 -10 -7c2.667 -4.667 6 -7 10 -7s7.333 2.333 10 7" /></svg>
-                                  </a>
-                                </span>
-                                #}
                             </div>
                         </div>
                         {% block remember_me %}

--- a/templates/security/confirmation.html.twig
+++ b/templates/security/confirmation.html.twig
@@ -3,9 +3,7 @@
 {% block login_social_auth %}{% endblock %}
 
 {% block login_form %}
-    {% block fos_user_content %}
-        <p>{{ 'registration.confirmed'|trans({'%username%': user.username}, 'TablerBundle') }}</p>
-    {% endblock fos_user_content %}
+    <p>{{ 'registration.confirmed'|trans({'%username%': user.username}, 'TablerBundle') }}</p>
 {% endblock %}
 
 {% block login_actions %}

--- a/templates/security/password-reset.html.twig
+++ b/templates/security/password-reset.html.twig
@@ -7,7 +7,7 @@
 {% endblock %}
 
 {% block login_form %}
-    <form class="card-body" action="{{ path('tabler_password_reset_sent'|tabler_route) }}" method="post" autocomplete="off">
+    <form class="card-body security-password-reset" action="{{ path('tabler_password_reset_sent'|tabler_route) }}" method="post" autocomplete="off">
         <div class="mb-3">
             <label class="form-label">{{ 'Username or email address'|trans({}, 'TablerBundle') }}</label>
             <input type="text" id="username" name="username" required="required" class="form-control" placeholder="{{ 'Username or email address'|trans({}, 'TablerBundle') }}">

--- a/templates/security/registration.html.twig
+++ b/templates/security/registration.html.twig
@@ -8,7 +8,7 @@
 
 {% block login_form %}
     {% form_theme form '@Tabler/layout/form-theme-security.html.twig' %}
-    {{ form_start(form, {'method': 'post', 'action': path('tabler_registration_register'|tabler_route), 'attr': {'class': 'fos_user_registration_register'}}) }}
+    {{ form_start(form, {'method': 'post', 'action': path('tabler_registration_register'|tabler_route), 'attr': {'class': 'security-registration'}}) }}
     {{ form_widget(form) }}
     <div class="form-footer">
         <button type="submit" class="btn btn-primary w-100">{{ 'Register'|trans({}, 'TablerBundle') }}</button>


### PR DESCRIPTION
## Description

Some random cleanup commits with tiny BC break if someone relied on the `fos_user_registration_register` class or used the `fos_user_content` block (which I hope nobody did).

My main purpose was to get rid of the last `fos_user` references from the AdminLTE era - fixes #33

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] I updated the documentation (see [here](https://github.com/kevinpapst/TablerBundle/tree/master/docs))
- [x] I agree that this code will be published under the [MIT license](https://github.com/kevinpapst/TablerBundle/blob/master/LICENSE)
