### PR TITLE
Allow custom attr in dropdown buttons

### DIFF
--- a/docs/components-buttons.md
+++ b/docs/components-buttons.md
@@ -84,13 +84,12 @@ TODO
 |  options  | Options object           | `object`  |  `{}`   |
 
 #### Item
-| Parameter | Description       |   Type    | Default |
-|:---------:|-------------------|:---------:|:-------:|
-|   icon    | Tabler icon name  | `boolean` | `false` |
-|   title   | Title of the item |  `html`   | `null`  |
-|    url    | Url of the item   | `string`  |   `#`   |
-|   class   | Custom class for dropdown item. results in class like `dropdown-item class`   | `string`  | `null`    |
-
+| Parameter | Description                                                                   |   Type    | Default |
+|:---------:|-------------------------------------------------------------------------------|:---------:|:-------:|
+|   icon    | Tabler icon name                                                              | `boolean` | `false` |
+|   title   | Title of the item                                                             |  `html`   | `null`  |
+|    url    | Url of the item                                                               | `string`  |   `#`   |
+|   class   | Custom class for dropdown item. Results in class like `dropdown-item class`   | `string`  | `null`  |
 
 ```twig
 {% from '@Tabler/components/buttons.html.twig' import dropdown_button %}

--- a/docs/components-buttons.md
+++ b/docs/components-buttons.md
@@ -89,6 +89,7 @@ TODO
 |   icon    | Tabler icon name  | `boolean` | `false` |
 |   title   | Title of the item |  `html`   | `null`  |
 |    url    | Url of the item   | `string`  |   `#`   |
+|   class   | Custom class for dropdown item. results in class like `dropdown-item class`   | `string`  | `null`    |
 
 
 ```twig
@@ -99,7 +100,7 @@ TODO
     [
         {icon: 'plus',      title : 'Add more',     url : '/add'},
         {                   title : 'Help needed',  url : '/help'},
-        {icon: 'delete',    title : 'Delete',       url : '/delete'}
+        {icon: 'delete',    title : 'Delete',       url : '/delete', class : 'my-class' }
     ]
 ) }}
 

--- a/templates/components/buttons.html.twig
+++ b/templates/components/buttons.html.twig
@@ -82,8 +82,9 @@
                     {% set _url     = action.url ?? '#' %}
                     {% set _icon    = action.icon ?? false %}
                     {% set _attr    = action.attr ?? {} %}
+                    {% set _class   = 'dropdown-item ' ~ (action.class ?? '') %}
 
-                    <a class="dropdown-item" href="{{ _url }}" {{ utils.attr_to_html(_attr) }}>
+                    <a class="{{ _class }}" href="{{ _url }}" {{ utils.attr_to_html(_attr) }}>
                         {%- if _icon is not same as (false) -%}
                             <span class="{{ options.icon_class }}">{{ tabler_icon(_icon, false) }}</span>
                         {% endif %}

--- a/templates/components/buttons.html.twig
+++ b/templates/components/buttons.html.twig
@@ -52,6 +52,7 @@
 
 {% macro dropdown_button(button, actions, options) %}
     {% import '@Tabler/components/button.html.twig' as macro %}
+    {% import '@Tabler/includes/utils.html.twig' as utils %}
 
     {% set button_default = {
         buttonType : 'button',
@@ -80,8 +81,9 @@
                     {% set _title   = action.title ?? null %}
                     {% set _url     = action.url ?? '#' %}
                     {% set _icon    = action.icon ?? false %}
+                    {% set _attr    = action.attr ?? {} %}
 
-                    <a class="dropdown-item" href="{{ _url }}">
+                    <a class="dropdown-item" href="{{ _url }}" {{ utils.attr_to_html(_attr) }}>
                         {%- if _icon is not same as (false) -%}
                             <span class="{{ options.icon_class }}">{{ tabler_icon(_icon, false) }}</span>
                         {% endif %}


### PR DESCRIPTION
## Description
This change allows `actions` of `dropdown_button` to have customized `attr` like any other button. This change allows to trigger modals etc. from within a dropdown.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] I updated the documentation (see [here](https://github.com/kevinpapst/TablerBundle/tree/master/docs))
- [x] I agree that this code will be published under the [MIT license](https://github.com/kevinpapst/TablerBundle/blob/master/LICENSE)
