### PR TITLE
Move Twig block "body_class" into the class attribute of BODY

### DIFF
--- a/templates/layout-horizontal.html.twig
+++ b/templates/layout-horizontal.html.twig
@@ -23,7 +23,7 @@ Enjoy your theme!
         {% endif %}
     {% endblock %}
 </head>
-<body{% block body_start %}{% endblock %} class="{{ 'antialiased'|tabler_body }}" {% block body_class %}{% endblock %}>
+<body{% block body_start %}{% endblock %} class="{{ 'antialiased'|tabler_body }} {% block body_class %}{% endblock %}">
 {% block after_body_start %}{% endblock %}
 <div class="page">
 

--- a/templates/layout-vertical.html.twig
+++ b/templates/layout-vertical.html.twig
@@ -23,7 +23,7 @@ Enjoy your theme!
         {% endif %}
     {% endblock %}
 </head>
-<body{% block body_start %}{% endblock %} class="{{ 'antialiased'|tabler_body }}" {% block body_class %}{% endblock %}>
+<body{% block body_start %}{% endblock %} class="{{ 'antialiased'|tabler_body }} {% block body_class %}{% endblock %}">
 {% block after_body_start %}{% endblock %}
 <div class="page">
     {% set navbarStartContent = block('navbar_start') %}


### PR DESCRIPTION
## Description
If we add class in the Twig block "body_class", the text is put AFTER the value of the class attribute.
Ex: 
`{% block body_class %}layout-boxed{% endblock %}`

Result:
`<body class="antialiased" layout-boxed>`

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] I updated the documentation (see [here](https://github.com/kevinpapst/TablerBundle/tree/master/docs))
- [X] I agree that this code will be published under the [MIT license](https://github.com/kevinpapst/TablerBundle/blob/master/LICENSE)
