### PR TITLE
include for html_head and rel=nofollow

### DIFF
--- a/templates/includes/html_head.html.twig
+++ b/templates/includes/html_head.html.twig
@@ -1,0 +1,4 @@
+<meta charset="utf-8">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<meta content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" name="viewport">
+<meta name="robots" content="noindex,nofollow">

--- a/templates/layout-horizontal.html.twig
+++ b/templates/layout-horizontal.html.twig
@@ -10,9 +10,7 @@ Enjoy your theme!
 <html lang="{{ app.request.locale }}"{% if tabler_bundle.isRightToLeft() %} dir="rtl"{% endif %}>
 <head>
     {% block head %}
-        <meta charset="utf-8"/>
-        <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover"/>
-        <meta http-equiv="X-UA-Compatible" content="ie=edge"/>
+        {% include '@Tabler/includes/html_head.html.twig' %}
     {% endblock %}
     <title>{% block title %}{{ block('page_title') }}{% endblock %}</title>
     {% block stylesheets %}

--- a/templates/layout-vertical.html.twig
+++ b/templates/layout-vertical.html.twig
@@ -10,9 +10,7 @@ Enjoy your theme!
 <html lang="{{ app.request.locale }}"{% if tabler_bundle.isRightToLeft() %} dir="rtl"{% endif %}>
 <head>
     {% block head %}
-        <meta charset="utf-8"/>
-        <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover"/>
-        <meta http-equiv="X-UA-Compatible" content="ie=edge"/>
+        {% include '@Tabler/includes/html_head.html.twig' %}
     {% endblock %}
     <title>{% block title %}{{ block('page_title') }}{% endblock %}</title>
     {% block stylesheets %}

--- a/templates/security.html.twig
+++ b/templates/security.html.twig
@@ -2,9 +2,7 @@
 <html lang="{{ app.request.locale }}"{% if tabler_bundle.isRightToLeft() %} dir="rtl"{% endif %}>
 <head>
     {% block head %}
-    <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" name="viewport">
+        {% include '@Tabler/includes/html_head.html.twig' %}
     {% endblock %}
     <title>{% block title %}Log in{% endblock %}</title>
     {% block stylesheets %}


### PR DESCRIPTION
## Description
- extract html head default tags to include (allows to override via new file in app `templates/bundles/TablerBundle/`templates/includes/html_head.html.twig`)
- add `rel=noindex.nofollow` to prevnt public apps from showing up in search engines

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] I agree that this code will be published under the [MIT license](https://github.com/kevinpapst/TablerBundle/blob/master/LICENSE)
