### PR TITLE
[Card] Refactoring V1

### DIFF
--- a/templates/embeds/card.html.twig
+++ b/templates/embeds/card.html.twig
@@ -1,3 +1,6 @@
+{% import '@Tabler/components/buttons.html.twig' as button %}
+{% block box_before %}{% endblock %}
+
 {# Options #}
 {% set _id                  = id ?? tabler_unique_id('box_') %}
 {% set _boxtype             = boxtype ?? null %}
@@ -37,10 +40,6 @@
 {% set _hasBody             = body is not empty %}
 {% set _hasFooter           = _use_footer or footer is not empty %}
 
-{% import '@Tabler/components/buttons.html.twig' as button %}
-{# ****************************** #}
-
-{% block box_before %}{% endblock %}
 {# Card #}
 <div id="{{ _id }}" class="card mb-{{ _margin_bottom }} {% block box_class %}{% endblock %}" {% block box_attributes %}{% endblock %}>
 

--- a/templates/embeds/card.html.twig
+++ b/templates/embeds/card.html.twig
@@ -9,13 +9,32 @@
 {% set _use_footer          = use_footer ?? false %}
 {% set _footer_collapsible  = footer_collapsible ?? true %}
 
+{# Common blocks #}
+{# Note : Used that way to prevent form field error `has already been rendered` #}
+{% set header -%}
+    {% block box_header %}{% endblock %}
+{%- endset %}
+
+{% set tools -%}
+    {% block box_tools %}{% endblock %}
+{%- endset %}
+
+{% set body -%}
+    {% block box_body %}{% endblock %}
+{%- endset %}
+
+{% set footer -%}
+    {% block box_footer %}{% endblock %}
+{%- endset %}
+
+
 {# *** Internal : do not mind *** #}
 {% set _collapsible_class   = tabler_unique_id('collapse_') %}
 
 {% set _hasTitle            = block('box_title') is defined and block('box_title') is not empty %}
-{% set _hasTools            = block('box_tools') is defined and block('box_tools') is not empty %}
-{% set _hasHeader           = block('box_header') is defined and block('box_header') is not empty %}
-{% set _hasBody             = block('box_body') is defined and block('box_body') is not empty %}
+{% set _hasTools            = tools is not empty %}
+{% set _hasHeader           = header is not empty %}
+{% set _hasBody             = body is not empty %}
 {% set _hasFooter           = _use_footer or (block('box_footer') is defined and block('box_footer') is not empty) %}
 
 {% import '@Tabler/components/buttons.html.twig' as button %}
@@ -35,12 +54,12 @@
     {% if _hasTitle or _collapsible or _hasTools or _hasHeader %}
         <div class="card-header {% block box_header_class %}{% endblock %}">
             {% if _hasHeader %}
-                {% block box_header %}{% endblock %}
+                {{ header|raw }}
             {% else %}
                 {% if _hasTitle %}<h3 class="card-title">{% block box_title %}{% endblock %}</h3>{% endif %}
                 <div class="card-actions" {% block box_tools_attributes %}{% endblock %}>
                     {# Buttons, labels, and many other things can be placed here! #}
-                    {% block box_tools %}{% endblock %}
+                    {{ tools|raw }}
                     {% if _collapsible %}
                         {{ button.action_collapsebutton(
                             collapsible_title|default('Toggle visibility'|trans({}, 'TablerBundle')),
@@ -56,7 +75,7 @@
     {# Body #}
     {% block box_body_before %}{% endblock %}
     <div class="card-body {% if _fullsize %}p-0{% endif %} {% if _collapsible %} {{ _collapsible_class ~ (_collapsed ? ' collapse' : ' show') }} {% endif %} {% block box_body_class %}{% endblock %}">
-        {% block box_body %}{% endblock %}
+        {{ body|raw }}
     </div>
     {% block box_body_after %}{% endblock %}
 
@@ -64,7 +83,7 @@
     {% block box_footer_before %}{% endblock %}
     {% if _hasFooter %}
         <div class="card-footer {% if _footer_collapsible %} {{ _collapsible_class ~ (_collapsed ? ' collapse' : ' show') }} {% endif %} {% block box_footer_class %}{% endblock %}">
-            {% block box_footer %}{% endblock %}
+            {{ footer|raw }}
         </div>
     {% endif %}
     {% block box_footer_after %}{% endblock %}

--- a/templates/embeds/card.html.twig
+++ b/templates/embeds/card.html.twig
@@ -1,34 +1,40 @@
-{% import '@Tabler/components/buttons.html.twig' as button %}
-{% block box_before %}{% endblock %}
-
-{% set _collapsed           = collapsed ?? false %}
-{% set _collapsible         = collapsible ?? _collapsed %}
-{% set _collapsible_class   = tabler_unique_id('collapse_') %}
-{% set _fullsize            = fullsize ?? false %}
-{% set _use_footer          = use_footer ?? false %}
-{% set _footer_collapsible  = footer_collapsible ?? true %}
+{# Options #}
+{% set _id                  = id|default(null) %}
 {% set _boxtype             = boxtype ?? null %}
 {% set _status_position     = status_position ?? 'top' %}
-{% set _id                  = id|default(null) %}
+{% set _fullsize            = fullsize ?? false %}
 {% set _margin_bottom       = margin_bottom ?? 3 %}
+{% set _collapsed           = collapsed ?? false %}
+{% set _collapsible         = collapsible ?? _collapsed %}
+{% set _footer_collapsible  = footer_collapsible ?? true %}
+{% set _use_footer          = use_footer ?? false %}
 
-{# Common blocks : Used that way to prevent form field error `has already been rendered` #}
+{# Common blocks : Declared this way to use `is not empty` and prevent the `has already been rendered` form field twig error #}
 {% set header %}{% block box_header %}{% endblock %}{% endset %}
 {% set tools %}{% block box_tools %}{% endblock %}{% endset %}
 {% set body %}{% block box_body %}{% endblock %}{% endset %}
 {% set footer %}{% block box_footer %}{% endblock %}{% endset %}
 {% set title %}{% block box_title %}{% endblock %}{% endset %}
 
+{% set _collapsible_class   = tabler_unique_id('collapse_') %}
 {% set _hasTitle            = title is not empty %}
 {% set _hasTools            = tools is not empty %}
 {% set _hasHeader           = header is not empty %}
 {% set _hasBody             = body is not empty %}
 {% set _hasFooter           = _use_footer or footer is not empty %}
 
-<div{% if _id is not null %} id="{{ _id }}"{% endif %} class="card {% block box_class %}{% endblock %} mb-{{ _margin_bottom }}" {% block box_attributes %}{% endblock %}>
+{% import '@Tabler/components/buttons.html.twig' as button %}
+
+{% block box_before %}{% endblock %}
+{# Card #}
+<div {% if _id is not null %}id="{{ _id }}"{% endif %} class="card {% block box_class %}{% endblock %} mb-{{ _margin_bottom }}" {% block box_attributes %}{% endblock %}>
+
+    {# Card Status #}
     {% if _boxtype is not null %}
         <div class="card-status-{{ _status_position }} bg-{{ _boxtype }}"></div>
     {% endif %}
+
+    {# Header #}
     {% block box_header_before %}{% endblock %}
     {% if _hasTitle or _collapsible or _hasTools or _hasHeader %}
         <div class="card-header {% block box_header_class %}{% endblock %}">
@@ -50,11 +56,15 @@
         </div>
     {% endif %}
     {% block box_header_after %}{% endblock %}
+
+    {# Body #}
     {% block box_body_before %}{% endblock %}
     <div class="card-body {% block box_body_class %}{% endblock %} {% if _fullsize %}p-0{% endif %} {% if _collapsible %} {{ _collapsible_class ~ (_collapsed ? ' collapse' : ' show') }} {% endif %}">
         {{ body|raw }}
     </div>
     {% block box_body_after %}{% endblock %}
+
+    {# Footer #}
     {% block box_footer_before %}{% endblock %}
     {% if _hasFooter %}
         <div class="card-footer {% if _footer_collapsible %} {{ _collapsible_class ~ (_collapsed ? ' collapse' : ' show') }} {% endif %} {% block box_footer_class %}{% endblock %}">
@@ -62,5 +72,6 @@
         </div>
     {% endif %}
     {% block box_footer_after %}{% endblock %}
+
 </div>
 {% block box_after %}{% endblock %}

--- a/templates/embeds/card.html.twig
+++ b/templates/embeds/card.html.twig
@@ -35,7 +35,7 @@
 {% set _hasTools            = tools is not empty %}
 {% set _hasHeader           = header is not empty %}
 {% set _hasBody             = body is not empty %}
-{% set _hasFooter           = _use_footer or (block('box_footer') is defined and block('box_footer') is not empty) %}
+{% set _hasFooter           = _use_footer or footer is not empty %}
 
 {% import '@Tabler/components/buttons.html.twig' as button %}
 {# ****************************** #}

--- a/templates/embeds/card.html.twig
+++ b/templates/embeds/card.html.twig
@@ -1,5 +1,5 @@
 {# Options #}
-{% set _id                  = id ?? uniqueId('box_') %}
+{% set _id                  = id ?? tabler_unique_id('box_') %}
 {% set _boxtype             = boxtype ?? null %}
 {% set _fullsize            = fullsize ?? false %}
 {% set _margin_bottom       = margin_bottom ?? 3 %}
@@ -10,7 +10,7 @@
 {% set _footer_collapsible  = footer_collapsible ?? true %}
 
 {# *** Internal : do not mind *** #}
-{% set _collapsible_class   = uniqueId('collapse_') %}
+{% set _collapsible_class   = tabler_unique_id('collapse_') %}
 
 {% set _hasTitle            = block('box_title') is defined and block('box_title') is not empty %}
 {% set _hasTools            = block('box_tools') is defined and block('box_tools') is not empty %}

--- a/templates/embeds/card.html.twig
+++ b/templates/embeds/card.html.twig
@@ -26,11 +26,9 @@
 {% set _hasFooter           = _use_footer or footer is not empty %}
 
 <div id="{{ _id }}" class="card mb-{{ _margin_bottom }} {% block box_class %}{% endblock %}" {% block box_attributes %}{% endblock %}>
-
     {% if _boxtype is not null %}
         <div class="card-status-{{ _status_position }} bg-{{ _boxtype }}"></div>
     {% endif %}
-
     {% block box_header_before %}{% endblock %}
     {% if _hasTitle or _collapsible or _hasTools or _hasHeader %}
         <div class="card-header {% block box_header_class %}{% endblock %}">
@@ -52,13 +50,11 @@
         </div>
     {% endif %}
     {% block box_header_after %}{% endblock %}
-
     {% block box_body_before %}{% endblock %}
     <div class="card-body {% if _fullsize %}p-0{% endif %} {% if _collapsible %} {{ _collapsible_class ~ (_collapsed ? ' collapse' : ' show') }} {% endif %} {% block box_body_class %}{% endblock %}">
         {{ body|raw }}
     </div>
     {% block box_body_after %}{% endblock %}
-
     {% block box_footer_before %}{% endblock %}
     {% if _hasFooter %}
         <div class="card-footer {% if _footer_collapsible %} {{ _collapsible_class ~ (_collapsed ? ' collapse' : ' show') }} {% endif %} {% block box_footer_class %}{% endblock %}">
@@ -66,6 +62,5 @@
         </div>
     {% endif %}
     {% block box_footer_after %}{% endblock %}
-
 </div>
 {% block box_after %}{% endblock %}

--- a/templates/embeds/card.html.twig
+++ b/templates/embeds/card.html.twig
@@ -12,43 +12,25 @@
 {% set _use_footer          = use_footer ?? false %}
 {% set _footer_collapsible  = footer_collapsible ?? true %}
 
-{# Common blocks #}
-{# Note : Used that way to prevent form field error `has already been rendered` #}
-{% set header -%}
-    {% block box_header %}{% endblock %}
-{%- endset %}
+{# Common blocks : Used that way to prevent form field error `has already been rendered` #}
+{% set header %}{% block box_header %}{% endblock %}{% endset %}
+{% set tools %}{% block box_tools %}{% endblock %}{% endset %}
+{% set body %}{% block box_body %}{% endblock %}{% endset %}
+{% set footer %}{% block box_footer %}{% endblock %}{% endset %}
 
-{% set tools -%}
-    {% block box_tools %}{% endblock %}
-{%- endset %}
-
-{% set body -%}
-    {% block box_body %}{% endblock %}
-{%- endset %}
-
-{% set footer -%}
-    {% block box_footer %}{% endblock %}
-{%- endset %}
-
-
-{# *** Internal : do not mind *** #}
 {% set _collapsible_class   = tabler_unique_id('collapse_') %}
-
 {% set _hasTitle            = block('box_title') is defined and block('box_title') is not empty %}
 {% set _hasTools            = tools is not empty %}
 {% set _hasHeader           = header is not empty %}
 {% set _hasBody             = body is not empty %}
 {% set _hasFooter           = _use_footer or footer is not empty %}
 
-{# Card #}
 <div id="{{ _id }}" class="card mb-{{ _margin_bottom }} {% block box_class %}{% endblock %}" {% block box_attributes %}{% endblock %}>
 
-    {# Card Status #}
     {% if _boxtype is not null %}
         <div class="card-status-{{ _status_position }} bg-{{ _boxtype }}"></div>
     {% endif %}
 
-    {# Header #}
     {% block box_header_before %}{% endblock %}
     {% if _hasTitle or _collapsible or _hasTools or _hasHeader %}
         <div class="card-header {% block box_header_class %}{% endblock %}">
@@ -71,14 +53,12 @@
     {% endif %}
     {% block box_header_after %}{% endblock %}
 
-    {# Body #}
     {% block box_body_before %}{% endblock %}
     <div class="card-body {% if _fullsize %}p-0{% endif %} {% if _collapsible %} {{ _collapsible_class ~ (_collapsed ? ' collapse' : ' show') }} {% endif %} {% block box_body_class %}{% endblock %}">
         {{ body|raw }}
     </div>
     {% block box_body_after %}{% endblock %}
 
-    {# Footer #}
     {% block box_footer_before %}{% endblock %}
     {% if _hasFooter %}
         <div class="card-footer {% if _footer_collapsible %} {{ _collapsible_class ~ (_collapsed ? ' collapse' : ' show') }} {% endif %} {% block box_footer_class %}{% endblock %}">

--- a/templates/embeds/card.html.twig
+++ b/templates/embeds/card.html.twig
@@ -1,57 +1,75 @@
+{# Options #}
+{% set _id                  = id ?? uniqueId('box_') %}
+{% set _boxtype             = boxtype ?? null %}
+{% set _fullsize            = fullsize ?? false %}
+{% set _margin_bottom       = margin_bottom ?? 3 %}
+{% set _status_position     = status_position ?? 'top' %}
+{% set _collapsed           = collapsed ?? false %}
+{% set _collapsible         = collapsible ?? _collapsed %}
+{% set _use_footer          = use_footer ?? false %}
+{% set _footer_collapsible  = footer_collapsible ?? true %}
+
+{# Blocks definition #}
+{% set _title               = block('box_title') is defined and block('box_title') is not empty ? block('box_title') : null %}
+{% set _tools               = block('box_tools') is defined and block('box_tools') is not empty ? block('box_tools') : null %}
+{% set _header              = block('box_header') is defined and block('box_header') is not empty ? block('box_header') : null %}
+
+{# Blocks conditions #}
+{% set _footer              = _use_footer or (block('box_footer') is defined and block('box_footer') is not empty) %}
+
+{# *** Internal : do not mind *** #}
+{% set _collapsible_class   = uniqueId('collapse_') %}
+{# ****************************** #}
+
 {% import '@Tabler/components/buttons.html.twig' as button %}
-{% if block('box_before') is defined %}{{ block('box_before') }}{% endif %}
 
-{% set _collapsed           = collapsed is defined ? collapsed : false %}
-{% set _collapsible         = collapsible is defined ? collapsible : _collapsed %}
-{% set _collapsible_class   = 'collapse_' ~ random() %}
-{% set _fullsize            = fullsize is defined ? fullsize : false %}
-{% set _footer              = use_footer|default(false) or block('box_footer') is defined %}
-{% set _footer_collapsible  = footer_collapsible is defined ? footer_collapsible : true %}
-{% set _boxtype             = boxtype|default(null) %}
-{% set _status_position     = status_position|default('top') %}
-{% set _id                  = id|default(null) %}
-{% set _title               = block('box_title') is defined ? block('box_title') : null %}
-{% set _tools               = block('box_tools') is defined ? block('box_tools') : null %}
-{% set _header              = block('box_header') is defined ? block('box_header') : null %}
-{% set _margin_bottom       = margin_bottom is defined ? margin_bottom : 3 %}
+{% block box_before %}{% endblock %}
+{# Card #}
+<div id="{{ _id }}" class="card mb-{{ _margin_bottom }} {% block box_class %}{% endblock %}" {% block box_attributes %}{% endblock %}>
 
-<div {% if _id is not null %}id="{{ _id }}"{% endif %} class="card mb-{{ _margin_bottom }}{% if block('box_class') is defined %} {{ block('box_class') }}{% endif %}"{% if block('box_attributes') is defined %} {{ block('box_attributes') }}{% endif %}>
+    {# Card Status #}
     {% if _boxtype is not null %}
-    <div class="card-status-{{ _status_position }} bg-{{ _boxtype }}"></div>
+        <div class="card-status-{{ _status_position }} bg-{{ _boxtype }}"></div>
     {% endif %}
-    {% if block('box_header_before') is defined %}{{ block('box_header_before') }}{% endif %}
+
+    {# Header #}
+    {% block box_header_before %}{% endblock %}
     {% if _title is not null or _collapsible or _tools is not null or _header is not null %}
-    <div class="card-header{% if block('box_header_class') is defined %} {{ block('box_header_class') }}{% endif %}">
-        {% if _header is not null %}
-            {{ _header|raw }}
-        {% else %}
-            {% if _title is not null %}<h3 class="card-title">{{ _title|raw }}</h3>{% endif %}
-            <div class="card-actions"{% if block('box_tools_attributes') is defined %} {{ block('box_tools_attributes') }}{% endif %}>
-                {# Buttons, labels, and many other things can be placed here! #}
-                {% if _tools is not null %}{{ _tools|raw }}{% endif %}
-                {% if _collapsible %}
-                    {{ button.action_collapsebutton(
-                        collapsible_title|default('Toggle visibility'|trans({}, 'TablerBundle')),
-                        '.' ~ _collapsible_class
-                    ) }}
-                {% endif %}
-            </div>
-        {% endif %}
+        <div class="card-header {% block box_header_class %}{% endblock %}">
+            {% if _header is not null %}
+                {{ _header|raw }}
+            {% else %}
+                {% if _title is not null %}<h3 class="card-title">{{ _title|raw }}</h3>{% endif %}
+                <div class="card-actions" {% block box_tools_attributes %}{% endblock %}>
+                    {# Buttons, labels, and many other things can be placed here! #}
+                    {% if _tools is not null %}{{ _tools|raw }}{% endif %}
+                    {% if _collapsible %}
+                        {{ button.action_collapsebutton(
+                            collapsible_title|default('Toggle visibility'|trans({}, 'TablerBundle')),
+                            '.' ~ _collapsible_class
+                        ) }}
+                    {% endif %}
+                </div>
+            {% endif %}
+        </div>
+    {% endif %}
+    {% block box_header_after %}{% endblock %}
+
+    {# Body #}
+    {% block box_body_before %}{% endblock %}
+    <div class="card-body {% if _fullsize %}p-0{% endif %} {% if _collapsible %} {{ _collapsible_class ~ (_collapsed ? ' collapse' : ' show') }} {% endif %} {% block box_body_class %}{% endblock %}">
+        {% block box_body %}{% endblock %}
     </div>
+    {% block box_body_after %}{% endblock %}
+
+    {# Footer #}
+    {% block box_footer_before %}{% endblock %}
+    {% if _footer %}
+        <div class="card-footer {% if _footer_collapsible %} {{ _collapsible_class ~ (_collapsed ? ' collapse' : ' show') }} {% endif %} {% block box_footer_class %}{% endblock %}">
+            {% block box_footer %}{% endblock %}
+        </div>
     {% endif %}
-    {% if block('box_header_after') is defined %}{{ block('box_header_after') }}{% endif %}
-    <div class="{% if _collapsible %}{{ _collapsible_class }} {% if _collapsed %}collapse {% else %}show {% endif %}{% endif %}card-body {% if block('box_body_class') is defined %}{{ block('box_body_class') }} {% endif %}{% if _fullsize %}p-0 {% endif %}">{{ block('box_body') }}</div>
-    {% if block('box_footer_before') is defined %}{{ block('box_footer_before') }}{% endif %}
-    {% if _footer and block('box_footer') is defined %}
-        {# 
-            If there is a form in the block_footer, it will be rendered when checking "is not empty". 
-            Therefor we have to cache the output first and then perform the checks. 
-        #}
-        {% set boxFooter = block('box_footer') %}
-        {% if boxFooter is not empty %}
-            <div class="card-footer {% if _footer_collapsible %} {{ _collapsible_class }}{% if _collapsed %} collapse{% else %} show{% endif %}{% endif %}">{{ boxFooter|raw }}</div>
-        {% endif %}
-    {% endif %}
-    {% if block('box_footer_after') is defined %}{{ block('box_footer_after') }}{% endif %}
+    {% block box_footer_after %}{% endblock %}
+
 </div>
-{% if block('box_after') is defined %}{{ block('box_after') }}{% endif %}
+{% block box_after %}{% endblock %}

--- a/templates/embeds/card.html.twig
+++ b/templates/embeds/card.html.twig
@@ -9,19 +9,17 @@
 {% set _use_footer          = use_footer ?? false %}
 {% set _footer_collapsible  = footer_collapsible ?? true %}
 
-{# Blocks definition #}
-{% set _title               = block('box_title') is defined and block('box_title') is not empty ? block('box_title') : null %}
-{% set _tools               = block('box_tools') is defined and block('box_tools') is not empty ? block('box_tools') : null %}
-{% set _header              = block('box_header') is defined and block('box_header') is not empty ? block('box_header') : null %}
-
-{# Blocks conditions #}
-{% set _footer              = _use_footer or (block('box_footer') is defined and block('box_footer') is not empty) %}
-
 {# *** Internal : do not mind *** #}
 {% set _collapsible_class   = uniqueId('collapse_') %}
-{# ****************************** #}
+
+{% set _hasTitle            = block('box_title') is defined and block('box_title') is not empty %}
+{% set _hasTools            = block('box_tools') is defined and block('box_tools') is not empty %}
+{% set _hasHeader           = block('box_header') is defined and block('box_header') is not empty %}
+{% set _hasBody             = block('box_body') is defined and block('box_body') is not empty %}
+{% set _hasFooter           = _use_footer or (block('box_footer') is defined and block('box_footer') is not empty) %}
 
 {% import '@Tabler/components/buttons.html.twig' as button %}
+{# ****************************** #}
 
 {% block box_before %}{% endblock %}
 {# Card #}
@@ -34,15 +32,15 @@
 
     {# Header #}
     {% block box_header_before %}{% endblock %}
-    {% if _title is not null or _collapsible or _tools is not null or _header is not null %}
+    {% if _hasTitle or _collapsible or _hasTools or _hasHeader %}
         <div class="card-header {% block box_header_class %}{% endblock %}">
-            {% if _header is not null %}
-                {{ _header|raw }}
+            {% if _hasHeader %}
+                {% block box_header %}{% endblock %}
             {% else %}
-                {% if _title is not null %}<h3 class="card-title">{{ _title|raw }}</h3>{% endif %}
+                {% if _hasTitle %}<h3 class="card-title">{% block box_title %}{% endblock %}</h3>{% endif %}
                 <div class="card-actions" {% block box_tools_attributes %}{% endblock %}>
                     {# Buttons, labels, and many other things can be placed here! #}
-                    {% if _tools is not null %}{{ _tools|raw }}{% endif %}
+                    {% block box_tools %}{% endblock %}
                     {% if _collapsible %}
                         {{ button.action_collapsebutton(
                             collapsible_title|default('Toggle visibility'|trans({}, 'TablerBundle')),
@@ -64,7 +62,7 @@
 
     {# Footer #}
     {% block box_footer_before %}{% endblock %}
-    {% if _footer %}
+    {% if _hasFooter %}
         <div class="card-footer {% if _footer_collapsible %} {{ _collapsible_class ~ (_collapsed ? ' collapse' : ' show') }} {% endif %} {% block box_footer_class %}{% endblock %}">
             {% block box_footer %}{% endblock %}
         </div>

--- a/templates/embeds/card.html.twig
+++ b/templates/embeds/card.html.twig
@@ -1,16 +1,16 @@
 {% import '@Tabler/components/buttons.html.twig' as button %}
 {% block box_before %}{% endblock %}
 
-{# Options #}
-{% set _id                  = id ?? tabler_unique_id('box_') %}
-{% set _boxtype             = boxtype ?? null %}
-{% set _fullsize            = fullsize ?? false %}
-{% set _margin_bottom       = margin_bottom ?? 3 %}
-{% set _status_position     = status_position ?? 'top' %}
 {% set _collapsed           = collapsed ?? false %}
 {% set _collapsible         = collapsible ?? _collapsed %}
+{% set _collapsible_class   = tabler_unique_id('collapse_') %}
+{% set _fullsize            = fullsize ?? false %}
 {% set _use_footer          = use_footer ?? false %}
 {% set _footer_collapsible  = footer_collapsible ?? true %}
+{% set _boxtype             = boxtype ?? null %}
+{% set _status_position     = status_position ?? 'top' %}
+{% set _id                  = id ?? tabler_unique_id('box_') %}
+{% set _margin_bottom       = margin_bottom ?? 3 %}
 
 {# Common blocks : Used that way to prevent form field error `has already been rendered` #}
 {% set header %}{% block box_header %}{% endblock %}{% endset %}
@@ -18,7 +18,6 @@
 {% set body %}{% block box_body %}{% endblock %}{% endset %}
 {% set footer %}{% block box_footer %}{% endblock %}{% endset %}
 
-{% set _collapsible_class   = tabler_unique_id('collapse_') %}
 {% set _hasTitle            = block('box_title') is defined and block('box_title') is not empty %}
 {% set _hasTools            = tools is not empty %}
 {% set _hasHeader           = header is not empty %}

--- a/templates/embeds/card.html.twig
+++ b/templates/embeds/card.html.twig
@@ -9,7 +9,7 @@
 {% set _footer_collapsible  = footer_collapsible ?? true %}
 {% set _boxtype             = boxtype ?? null %}
 {% set _status_position     = status_position ?? 'top' %}
-{% set _id                  = id ?? tabler_unique_id('box_') %}
+{% set _id                  = id|default(null) %}
 {% set _margin_bottom       = margin_bottom ?? 3 %}
 
 {# Common blocks : Used that way to prevent form field error `has already been rendered` #}
@@ -17,14 +17,15 @@
 {% set tools %}{% block box_tools %}{% endblock %}{% endset %}
 {% set body %}{% block box_body %}{% endblock %}{% endset %}
 {% set footer %}{% block box_footer %}{% endblock %}{% endset %}
+{% set title %}{% block box_title %}{% endblock %}{% endset %}
 
-{% set _hasTitle            = block('box_title') is defined and block('box_title') is not empty %}
+{% set _hasTitle            = title is not empty %}
 {% set _hasTools            = tools is not empty %}
 {% set _hasHeader           = header is not empty %}
 {% set _hasBody             = body is not empty %}
 {% set _hasFooter           = _use_footer or footer is not empty %}
 
-<div id="{{ _id }}" class="card mb-{{ _margin_bottom }} {% block box_class %}{% endblock %}" {% block box_attributes %}{% endblock %}>
+<div{% if _id is not null %} id="{{ _id }}"{% endif %} class="card {% block box_class %}{% endblock %} mb-{{ _margin_bottom }}" {% block box_attributes %}{% endblock %}>
     {% if _boxtype is not null %}
         <div class="card-status-{{ _status_position }} bg-{{ _boxtype }}"></div>
     {% endif %}
@@ -34,7 +35,7 @@
             {% if _hasHeader %}
                 {{ header|raw }}
             {% else %}
-                {% if _hasTitle %}<h3 class="card-title">{% block box_title %}{% endblock %}</h3>{% endif %}
+                {% if _hasTitle %}<h3 class="card-title">{{ title }}</h3>{% endif %}
                 <div class="card-actions" {% block box_tools_attributes %}{% endblock %}>
                     {# Buttons, labels, and many other things can be placed here! #}
                     {{ tools|raw }}
@@ -50,7 +51,7 @@
     {% endif %}
     {% block box_header_after %}{% endblock %}
     {% block box_body_before %}{% endblock %}
-    <div class="card-body {% if _fullsize %}p-0{% endif %} {% if _collapsible %} {{ _collapsible_class ~ (_collapsed ? ' collapse' : ' show') }} {% endif %} {% block box_body_class %}{% endblock %}">
+    <div class="card-body {% block box_body_class %}{% endblock %} {% if _fullsize %}p-0{% endif %} {% if _collapsible %} {{ _collapsible_class ~ (_collapsed ? ' collapse' : ' show') }} {% endif %}">
         {{ body|raw }}
     </div>
     {% block box_body_after %}{% endblock %}


### PR DESCRIPTION
## Description
Here we go... I finally did it by need.
I was tired of not having auto-completion from Symfony PhpStorm plugin
and searching 30 minutes every-time what I need to change on that embed..

There are NO deleted options/variables/blocks.
Only new ones.

So it should not BC.

## ⚠️ Block condition is now to `is empty` ⚠️

It allows dev to "unset" block by setting them at an empty string.
That means:

#### This will not be print
<table>
<tr>
<td>

```twig
{% block box_footer %}{% endblock %}
```
</td>
</tr>
<tr>
<td>

```twig
{% block box_footer -%}
{%- endblock %}
```
</td>
</tr>
</table>

#### But this will be printed:

<table>
<tr>
<td>

```twig
{% block box_footer %} {% endblock %}
```
</td>
</tr>
<tr>
<td>

```twig
{% block box_footer %}
{% endblock %}
```
</td>
</tr>
</table>

## Examples

```twig
{% embed '@Tabler/embeds/card.html.twig' %}
    {% block box_title %}Title{% endblock %}
{% endembed %}

{% embed '@Tabler/embeds/card.html.twig' with {boxtype : 'danger'} %}
    {% block box_title %}Status/Type{% endblock %}
{% endembed %}

{% embed '@Tabler/embeds/card.html.twig' %}
    {% block box_header %}<h1 class="m-0">HTML <span class="badge">Header</span></h1>{% endblock %}
{% endembed %}

{% embed '@Tabler/embeds/card.html.twig' with {collapsible : true} %}
    {% block box_title %}Collapsible{% endblock %}
{% endembed %}

{% embed '@Tabler/embeds/card.html.twig' with {collapsed : true} %}
    {% block box_title %}Collapsed{% endblock %}
    {% block box_body %}But not collapsible{% endblock %}
{% endembed %}

{% embed '@Tabler/embeds/card.html.twig' with {collapsible : true} %}
    {% from '@Tabler/components/button.html.twig' import button %}
    {% block box_title %}Custom tools{% endblock %}
    {% block box_tools %}
        {{ button(false,{title : 'button 1'}, 'success') }}
        {{ button(false,{title : 'button 2'}, 'warning') }}
    {% endblock %}
{% endembed %}

{% embed '@Tabler/embeds/card.html.twig' %}
    {% block box_title %}Custom class{% endblock %}
    {% block box_class %}bg-success-lt{% endblock %}
{% endembed %}

{% embed '@Tabler/embeds/card.html.twig' with {fullsize : true} %}
    {% block box_title %}Fullsize{% endblock %}
    {% block box_body %}My content should be really close to the card (without padding){% endblock %}
{% endembed %}

{% embed '@Tabler/embeds/card.html.twig' %}
    {% block box_title %}Footer{% endblock %}
    {% block box_footer %}I'm a footer{% endblock %}
{% endembed %}

{% embed '@Tabler/embeds/card.html.twig' %}
    {% block box_title %}Footer block empty{% endblock %}
    {% block box_footer %}{% endblock %}
{% endembed %}

{% embed '@Tabler/embeds/card.html.twig' %}
    {% block box_title %}Footer block with space{% endblock %}
    {% block box_footer %} {% endblock %}
{% endembed %}

{% embed '@Tabler/embeds/card.html.twig' %}
    {% block box_title %}Footer block with new line{% endblock %}
    {% block box_footer %}
    {% endblock %}
{% endembed %}

{% embed '@Tabler/embeds/card.html.twig' with {use_footer : true} %}
    {% block box_title %}Footer displayed but empty from param{% endblock %}
{% endembed %}

{% embed '@Tabler/embeds/card.html.twig' with {collapsible : true} %}
    {% block box_title %}Collapsible with footer{% endblock %}
    {% block box_footer %}Am I hidden?{% endblock %}
{% endembed %}
```

![image](https://user-images.githubusercontent.com/25293190/210978497-2e034eb3-6a91-43be-95e6-103e4417d2ca.png)



## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] I updated the documentation (see [here](https://github.com/kevinpapst/TablerBundle/tree/master/docs))
- [x] I agree that this code will be published under the [MIT license](https://github.com/kevinpapst/TablerBundle/blob/master/LICENSE)
