### PR TITLE
[Accordion] Add a more secure random `id`

### DIFF
--- a/docs/components-accordion.md
+++ b/docs/components-accordion.md
@@ -29,13 +29,13 @@ See Tabler documentation at https://preview.tabler.io/accordion.html
 | bodyExtraClass  | Add extra class to the body      | `string`  | _empty string_ |
 
 #### Options
-|  Parameter  | Description                                                                                                               |   Type    |             Default             |
-|:-----------:|---------------------------------------------------------------------------------------------------------------------------|:---------:|:-------------------------------:|
-|     id      | Set custom `id` to accordion                                                                                              |  `mixed`  | `'accordion-'` + `rand(0, 999)` |                                        
-|     raw     | Use raw output for `title` and `body`                                                                                     | `boolean` |             `true`              |                                        
-|    flush    | Remove certains styles (see [Boostrap docs](https://getbootstrap.com/docs/5.0/components/accordion/#flush))               | `boolean` |             `false`             | 
-| alwaysOpen  | Make accordion items stay open (see [Bootstrap Doc](https://getbootstrap.com/docs/5.0/components/accordion/#always-open)) | `boolean` |             `false`             |   
-| extraClass  | Add extra classes on accordion container                                                                                  | `string`  |         _empty string_          |      
+| Parameter  | Description                                                                                                                  |   Type    |             Default              |
+|:----------:|------------------------------------------------------------------------------------------------------------------------------|:---------:|:--------------------------------:|
+|     id     | Set custom `id` to accordion                                                                                                 | `string`  | `tabler_unique_id('accordion_')` |                                        
+|    raw     | Use raw output for `title` and `body`                                                                                        | `boolean` |              `true`              |                                        
+|   flush    | Remove certains styles (see [Boostrap docs](https://getbootstrap.com/docs/5.0/components/accordion/#flush))                  | `boolean` |             `false`              | 
+| alwaysOpen | Holds the accordion elements open (see [Bootstrap Doc](https://getbootstrap.com/docs/5.0/components/accordion/#always-open)) | `boolean` |             `false`              |   
+| extraClass | Add extra classes on accordion container                                                                                     | `string`  |          _empty string_          |      
 
 ### Usage
 

--- a/templates/components/accordion.html.twig
+++ b/templates/components/accordion.html.twig
@@ -1,7 +1,7 @@
 {% macro accordion(items, options) %}
 
     {# Options #}
-    {% set _id = options.id ?? ('accordion-' ~ random(0, 999)) %}
+    {% set _id = options.id ?? tabler_unique_id('accordion_') %}
     {% set _raw = options.raw ?? true %}
     {% set _flush = options.flush ?? false %}
     {% set _always_open = options.alwaysOpen ?? false %}
@@ -11,7 +11,7 @@
         {% for item in items %}
 
             {# Item #}
-            {% set _id_collapse = _id ~ '-collapse-' ~ loop.index %}
+            {% set _id_collapse = _id ~ '_collapse_' ~ loop.index %}
             {% set _item_title = item.title ?? '' %}
             {% set _item_body = item.body ?? '' %}
 


### PR DESCRIPTION
## Description
Had clients that have the same ID for a 8 items accordion..
999 possibilities is not enough to not have duplicates.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I updated the documentation (see [here](https://github.com/kevinpapst/TablerBundle/tree/master/docs))
- [x] I agree that this code will be published under the [MIT license](https://github.com/kevinpapst/TablerBundle/blob/master/LICENSE)
