### PR TITLE
[Login] Add Login-cover page

### DIFF
--- a/docs/layout.md
+++ b/docs/layout.md
@@ -32,7 +32,7 @@ The `security.html.twig` file for login, register ... can be used with:
 
 See example at [https://preview.tabler.io/sign-in.html](https://preview.tabler.io/sign-in.html)
 
-**For your security screens (with huge cover image**
+**For your security screens (with huge cover image)**
 
 The `security-cover.html.twig` file for login, register ... can be used with:   
 ```

--- a/docs/layout.md
+++ b/docs/layout.md
@@ -34,7 +34,7 @@ See example at [https://preview.tabler.io/sign-in.html](https://preview.tabler.i
 
 **For your security screens (with huge cover image)**
 
-The `security-cover.html.twig` file for login, register ... can be used with:   
+The `security-cover.html.twig` file (for login, register, ...) can be used with:   
 ```
 {% extends '@Tabler/security-cover.html.twig' %}
 ```

--- a/docs/layout.md
+++ b/docs/layout.md
@@ -30,6 +30,19 @@ The `security.html.twig` file for login, register ... can be used with:
 {% extends '@Tabler/security.html.twig' %}
 ```
 
+See example at [https://preview.tabler.io/sign-in.html](https://preview.tabler.io/sign-in.html)
+
+**For your security screens (with huge cover image**
+
+The `security-cover.html.twig` file for login, register ... can be used with:   
+```
+{% extends '@Tabler/security-cover.html.twig' %}
+```
+
+The cover image is configurable at `tabler.options.security_cover_url` or via `ConextHelper::setSecurityCoverUrl()`.
+
+See example at [https://preview.tabler.io/sign-in-cover.html](https://preview.tabler.io/sign-in-cover.html)
+
 **For your error pages**
 
 The `error.html.twig` for all of your [error pages](error_pages.md):   

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -152,6 +152,9 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('logo_url')
                     ->defaultNull()
                 ->end()
+                ->scalarNode('security_cover_url')
+                    ->defaultValue('https://placehold.co/1000')
+                ->end()
             ->end()
         ->end();
 

--- a/src/Helper/ContextHelper.php
+++ b/src/Helper/ContextHelper.php
@@ -101,6 +101,16 @@ class ContextHelper extends \ArrayObject
         $this->setOption('boxed_layout', $boxed);
     }
 
+    public function getSecurityCoverUrl(): string
+    {
+        return (string) $this->getOption('security_cover_url');
+    }
+
+    public function setSecurityCoverUrl(string $url): void
+    {
+        $this->setOption('security_cover_url', $url);
+    }
+
     public function getOptions(): array
     {
         return $this->getArrayCopy();

--- a/templates/security-cover.html.twig
+++ b/templates/security-cover.html.twig
@@ -100,7 +100,7 @@
 
     <div class="col-12 col-lg-6 col-xl-8 d-none d-lg-block">
         {% block before_cover %}{% endblock %}
-        <div class="{% block cover_classes %}bg-cover h-100 min-vh-100{% endblock %}" style="{% block cover_style %}background-image: url({% block cover_url %}https://placehold.co/1000{% endblock %}){% endblock %}"></div>
+        <div class="{% block cover_classes %}bg-cover h-100 min-vh-100{% endblock %}" style="{% block cover_style %}background-image: url({% block cover_url %}{{ tabler_bundle.getSecurityCoverUrl() }}{% endblock %}){% endblock %}"></div>
         {% block after_cover %}{% endblock %}
     </div>
 </div>

--- a/templates/security-cover.html.twig
+++ b/templates/security-cover.html.twig
@@ -1,4 +1,4 @@
-{% extends 'security.html.twig' %}
+{% extends '@Tabler/security.html.twig' %}
 
 {% block page_classes %}row g-0 flex-fill{% endblock %}
 {% block container_before %}

--- a/templates/security-cover.html.twig
+++ b/templates/security-cover.html.twig
@@ -12,9 +12,9 @@
     {% block container_after %}
 </div>
 
-    <div class="col-12 col-lg-6 col-xl-8 d-none d-lg-block">
-        {% block before_cover %}{% endblock %}
-        <div class="{% block cover_classes %}bg-cover h-100 min-vh-100{% endblock %}" style="{% block cover_style %}background-image: url({% block cover_url %}{{ tabler_bundle.getSecurityCoverUrl() }}{% endblock %}){% endblock %}"></div>
-        {% block after_cover %}{% endblock %}
-    </div>
+<div class="col-12 col-lg-6 col-xl-8 d-none d-lg-block">
+    {% block before_cover %}{% endblock %}
+    <div class="{% block cover_classes %}bg-cover h-100 min-vh-100{% endblock %}" style="{% block cover_style %}background-image: url({% block cover_url %}{{ tabler_bundle.getSecurityCoverUrl() }}{% endblock %}){% endblock %}"></div>
+    {% block after_cover %}{% endblock %}
+</div>
 {% endblock %}

--- a/templates/security-cover.html.twig
+++ b/templates/security-cover.html.twig
@@ -1,112 +1,19 @@
-<!doctype html{% block html_start %}{% endblock %}>
-<html lang="{{ app.request.locale }}"{% if tabler_bundle.isRightToLeft() %} dir="rtl"{% endif %}>
-<head>
-    {% block head %}
-        {% include '@Tabler/includes/html_head.html.twig' %}
+{% extends 'security.html.twig' %}
+
+{% block page_classes %}row g-0 flex-fill{% endblock %}
+{% block container_before %}
+<div class="col-12 col-lg-6 col-xl-4 {% block login_border %}border-top-wide border-primary{% endblock %} d-flex flex-column justify-content-center">
     {% endblock %}
-    <title>{% block title %}Log in{% endblock %}</title>
-    {% block stylesheets %}
-        {% if tabler_bundle.isRightToLeft() %}
-            <link rel="stylesheet" href="{{ asset('bundles/tabler/tabler-rtl.css') }}">
-        {% else %}
-            <link rel="stylesheet" href="{{ asset('bundles/tabler/tabler.css') }}">
-        {% endif %}
-    {% endblock %}
-</head>
-<body{% block body_start %}{% endblock %} class="{% block body_classes %}d-flex flex-column {% block body_class %}bg-white theme-light{% endblock %}{% endblock %}">
-{% block after_body_start %}{% endblock %}
-<div class="row g-0 flex-fill">
-    <div class="col-12 col-lg-6 col-xl-4 {% block login_border %}border-top-wide border-primary{% endblock %} d-flex flex-column justify-content-center">
-        <div class="container container-tight my-5 px-lg-5">
-            <div class="text-center mb-4">
-                <h1>{% block logo_login %}Tabler{% endblock %}</h1>
-            </div>
-            <h2 class="h3 text-center mb-4">{% block login_box_msg %}{% endblock %}</h2>
-            {% block login_box_error %}
-                {% if error|default(false) %}
-                    <div class="alert alert-important alert-danger">{{ error.messageKey|trans(error.messageData, 'security') }}</div>
-                {% endif %}
-            {% endblock %}
-            {% block login_form %}
-                <form action="{{ path('tabler_login_check'|tabler_route) }}" method="post" autocomplete="off" class="login-box-body security-login">
-                    {% block login_form_start %}{% endblock %}
-                    <div class="mb-3">
-                        <label for="username" class="form-label">{{ 'Username'|trans({}, 'TablerBundle') }}</label>
-                        <input id="username" type="text" name="_username" tabindex="10" class="form-control" placeholder="{{ 'Username'|trans({}, 'TablerBundle') }}" value="{{ last_username|default('') }}">
-                    </div>
-                    <div class="mb-3">
-                        <label for="password" class="form-label">
-                            {{ 'Password'|trans({}, 'TablerBundle') }}
-                            {% block password_forgotten %}
-                                {% if 'tabler_password_reset'|tabler_route != 'tabler_password_reset' %}
-                                    <span class="form-label-description">
-                                        <a href="{{ path('tabler_password_reset'|tabler_route) }}" tabindex="100">{{ 'I forgot my password'|trans({}, 'TablerBundle') }}</a>
-                                    </span>
-                                {% endif %}
-                            {% endblock %}
-                        </label>
-                        <div class="input-group input-group-flat">
-                            <input id="password" name="_password" type="password" tabindex="20" class="form-control" placeholder="{{ 'Password'|trans({}, 'TablerBundle') }}">
-                        </div>
-                    </div>
-                    {% block remember_me %}
-                        <div class="mb-3">
-                            <label class="form-check">
-                                <input id="remember_me" tabindex="30" name="_remember_me" type="checkbox" class="form-check-input">
-                                <span class="form-check-label">{{ 'Remember Me'|trans({}, 'TablerBundle') }}</span>
-                            </label>
-                        </div>
-                    {% endblock %}
-                    <div class="form-footer">
-                        <button type="submit" tabindex="40" class="btn btn-primary w-100">{{ 'Sign In'|trans({}, 'TablerBundle') }}</button>
-                    </div>
-                    {% block csrf_token %}
-                        <input type="hidden" name="_csrf_token" value="{{ csrf_token('authenticate') }}"/>
-                    {% endblock %}
-                    {% block login_form_end %}{% endblock %}
-                </form>
-            {% endblock %}
-            {% block login_social_auth %}
-                <div class="hr-text">{{ 'or'|trans({}, 'TablerBundle') }}</div>
-                <div class="card-body">
-                    <div class="row">
-                        <div class="col">
-                            <a href="#" class="btn btn-white w-100">
-                                <i class="icon fab fa-github text-github"></i> Github
-                            </a>
-                        </div>
-                        <div class="col">
-                            <a href="#" class="btn btn-white w-100">
-                                <i class="icon fab fa-twitter text-twitter"></i> Twitter
-                            </a>
-                        </div>
-                    </div>
-                </div>
-            {% endblock %}
-            
-            {% block login_actions %}
-                {% block registration %}
-                    {% if 'tabler_registration'|tabler_route != 'tabler_registration' %}
-                        <div class="text-center text-muted mt-3">
-                            <a href="{{ path('tabler_registration'|tabler_route) }}">
-                                {{ 'Register a new account'|trans({}, 'TablerBundle') }}
-                            </a>
-                        </div>
-                    {% endif %}
-                {% endblock %}
-            {% endblock %}
-        </div>
-    </div>
+
+    {% block container_classes %}container container-tight my-5 px-lg-5{% endblock %}
+    {% block card_classes %}{% endblock %}
+
+    {% block container_after %}
+</div>
 
     <div class="col-12 col-lg-6 col-xl-8 d-none d-lg-block">
         {% block before_cover %}{% endblock %}
         <div class="{% block cover_classes %}bg-cover h-100 min-vh-100{% endblock %}" style="{% block cover_style %}background-image: url({% block cover_url %}{{ tabler_bundle.getSecurityCoverUrl() }}{% endblock %}){% endblock %}"></div>
         {% block after_cover %}{% endblock %}
     </div>
-</div>
-
-{% block javascripts %}
-    <script src="{{ asset('bundles/tabler/tabler.js') }}"></script>
 {% endblock %}
-</body>
-</html>

--- a/templates/security-cover.html.twig
+++ b/templates/security-cover.html.twig
@@ -1,5 +1,6 @@
 {% extends '@Tabler/security.html.twig' %}
 
+{% block body_login_border %}{% endblock %}
 {% block page_classes %}row g-0 flex-fill{% endblock %}
 {% block container_before %}
 <div class="col-12 col-lg-6 col-xl-4 {% block login_border %}border-top-wide border-primary{% endblock %} d-flex flex-column justify-content-center">

--- a/templates/security.html.twig
+++ b/templates/security.html.twig
@@ -15,13 +15,15 @@
 </head>
 <body{% block body_start %}{% endblock %} class="antialiased border-top-wide border-primary d-flex flex-column {% block body_class %}{% endblock %}">
 {% block after_body_start %}{% endblock %}
-<div class="page page-center">
-    <div class="container-tight py-4">
+{% block page_before %}{% endblock %}
+<div class="{% block page_classes %}page page-center{% endblock %}">
+    {% block container_before %}{% endblock %}
+    <div class="{% block container_classes %}container-tight py-4{% endblock %}">
         <div class="text-center mb-4">
             <h1>{% block logo_login %}Tabler{% endblock %}</h1>
         </div>
 
-        <div class="card card-md">
+        <div class="{% block card_classes %}card card-md{% endblock %}">
             {% block login_box %}
             <div class="card-body">
                 <h2 class="card-title text-center mb-4">{% block login_box_msg %}{% endblock %}</h2>
@@ -71,6 +73,7 @@
                 {% endblock %}
             </div>
             {% endblock %}
+
             {% block login_social_auth %}
             <div class="hr-text">{{ 'or'|trans({}, 'TablerBundle') }}</div>
             <div class="card-body">
@@ -102,6 +105,7 @@
             {% endblock %}
         {% endblock %}
     </div>
+    {% block container_after %}{% endblock %}
 </div>
 
 {% block javascripts %}

--- a/templates/security.html.twig
+++ b/templates/security.html.twig
@@ -13,7 +13,7 @@
         {% endif %}
     {% endblock %}
 </head>
-<body{% block body_start %}{% endblock %} class="antialiased border-top-wide border-primary d-flex flex-column {% block body_class %}{% endblock %}">
+<body{% block body_start %}{% endblock %} class="antialiased {% block body_login_border %}border-top-wide border-primary{% endblock %} d-flex flex-column {% block body_class %}{% endblock %}">
 {% block after_body_start %}{% endblock %}
 {% block page_before %}{% endblock %}
 <div class="{% block page_classes %}page page-center{% endblock %}">

--- a/templates/security/login-cover.html.twig
+++ b/templates/security/login-cover.html.twig
@@ -1,0 +1,97 @@
+<!doctype html{% block html_start %}{% endblock %}>
+<html lang="{{ app.request.locale }}"{% if tabler_bundle.isRightToLeft() %} dir="rtl"{% endif %}>
+<head>
+    {% block head %}
+        {% include '@Tabler/includes/html_head.html.twig' %}
+    {% endblock %}
+    <title>{% block title %}Log in{% endblock %}</title>
+    {% block stylesheets %}
+        {% if tabler_bundle.isRightToLeft() %}
+            <link rel="stylesheet" href="{{ asset('bundles/tabler/tabler-rtl.css') }}">
+        {% else %}
+            <link rel="stylesheet" href="{{ asset('bundles/tabler/tabler.css') }}">
+        {% endif %}
+    {% endblock %}
+</head>
+<body{% block body_start %}{% endblock %} class="{% block body_classes %}d-flex flex-column {% block body_class %}bg-white theme-light{% endblock %}{% endblock %}">
+{% block after_body_start %}{% endblock %}
+<div class="row g-0 flex-fill">
+    <div class="col-12 col-lg-6 col-xl-4 {% block login_border %}border-top-wide border-primary{% endblock %} d-flex flex-column justify-content-center">
+        <div class="container container-tight my-5 px-lg-5">
+            <div class="text-center mb-4">
+                <h1>{% block logo_login %}Tabler{% endblock %}</h1>
+            </div>
+            <h2 class="h3 text-center mb-3">
+                {% block login_box_msg %}{% endblock %}
+            </h2>
+            {% block login_box_error %}
+                {% if error|default(false) %}
+                    <div class="alert alert-important alert-danger">{{ error.messageKey|trans(error.messageData, 'security') }}</div>
+                {% endif %}
+            {% endblock %}
+            {% block login_form %}
+                <form action="{{ path('tabler_login_check'|tabler_route) }}" method="post" autocomplete="off" class="login-box-body security-login">
+                    {% block login_form_start %}{% endblock %}
+                    <div class="mb-3">
+                        <label class="form-label">{{ 'Username'|trans({}, 'TablerBundle') }}</label>
+                        <input type="text" name="_username" tabindex="10" class="form-control" placeholder="{{ 'Username'|trans({}, 'TablerBundle') }}" value="{{ last_username|default('') }}">
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label">
+                            {{ 'Password'|trans({}, 'TablerBundle') }}
+                            {% block password_forgotten %}
+                                {% if 'tabler_password_reset'|tabler_route != 'tabler_password_reset' %}
+                                    <span class="form-label-description">
+                                            <a href="{{ path('tabler_password_reset'|tabler_route) }}" tabindex="100">{{ 'I forgot my password'|trans({}, 'TablerBundle') }}</a>
+                                        </span>
+                                {% endif %}
+                            {% endblock %}
+                        </label>
+                        <div class="input-group input-group-flat">
+                            <input name="_password" type="password" tabindex="20" class="form-control" placeholder="{{ 'Password'|trans({}, 'TablerBundle') }}">
+                        </div>
+                    </div>
+                    {% block remember_me %}
+                        <div class="mb-3">
+                            <label class="form-check">
+                                <input id="remember_me" tabindex="30" name="_remember_me" type="checkbox" class="form-check-input">
+                                <span class="form-check-label">{{ 'Remember Me'|trans({}, 'TablerBundle') }}</span>
+                            </label>
+                        </div>
+                    {% endblock %}
+                    <div class="form-footer">
+                        <button type="submit" tabindex="40" class="btn btn-primary w-100">{{ 'Sign In'|trans({}, 'TablerBundle') }}</button>
+                    </div>
+                    {% block csrf_token %}
+                        <input type="hidden" name="_csrf_token" value="{{ csrf_token('authenticate') }}"/>
+                    {% endblock %}
+                    {% block login_form_end %}{% endblock %}
+                </form>
+            {% endblock %}
+
+            {% block login_actions %}
+                {% block registration %}
+                    {% if 'tabler_registration'|tabler_route != 'tabler_registration' %}
+                        <div class="text-center text-muted mt-3">
+                            <a href="{{ path('tabler_registration'|tabler_route) }}">
+                                {{ 'Register a new account'|trans({}, 'TablerBundle') }}
+                            </a>
+                        </div>
+                    {% endif %}
+                {% endblock %}
+            {% endblock %}
+        </div>
+    </div>
+
+    <div class="col-12 col-lg-6 col-xl-8 d-none d-lg-block">
+        {% block before_cover %}{% endblock %}
+        <div class="{% block cover_classes %}bg-cover h-100 min-vh-100{% endblock %}" style="{% block cover_style %}background-image: url(https://placehold.co/1000){% endblock %}"></div>
+        {% block after_cover %}{% endblock %}
+    </div>
+</div>
+
+{% block javascripts %}
+    <script src="{{ asset('bundles/tabler/tabler.js') }}"></script>
+{% endblock %}
+</body>
+</html>

--- a/templates/security/login-cover.html.twig
+++ b/templates/security/login-cover.html.twig
@@ -21,9 +21,7 @@
             <div class="text-center mb-4">
                 <h1>{% block logo_login %}Tabler{% endblock %}</h1>
             </div>
-            <h2 class="h3 text-center mb-3">
-                {% block login_box_msg %}{% endblock %}
-            </h2>
+            <h2 class="h3 text-center mb-4">{% block login_box_msg %}{% endblock %}</h2>
             {% block login_box_error %}
                 {% if error|default(false) %}
                     <div class="alert alert-important alert-danger">{{ error.messageKey|trans(error.messageData, 'security') }}</div>
@@ -33,22 +31,22 @@
                 <form action="{{ path('tabler_login_check'|tabler_route) }}" method="post" autocomplete="off" class="login-box-body security-login">
                     {% block login_form_start %}{% endblock %}
                     <div class="mb-3">
-                        <label class="form-label">{{ 'Username'|trans({}, 'TablerBundle') }}</label>
-                        <input type="text" name="_username" tabindex="10" class="form-control" placeholder="{{ 'Username'|trans({}, 'TablerBundle') }}" value="{{ last_username|default('') }}">
+                        <label for="username" class="form-label">{{ 'Username'|trans({}, 'TablerBundle') }}</label>
+                        <input id="username" type="text" name="_username" tabindex="10" class="form-control" placeholder="{{ 'Username'|trans({}, 'TablerBundle') }}" value="{{ last_username|default('') }}">
                     </div>
                     <div class="mb-3">
-                        <label class="form-label">
+                        <label for="password" class="form-label">
                             {{ 'Password'|trans({}, 'TablerBundle') }}
                             {% block password_forgotten %}
                                 {% if 'tabler_password_reset'|tabler_route != 'tabler_password_reset' %}
                                     <span class="form-label-description">
-                                            <a href="{{ path('tabler_password_reset'|tabler_route) }}" tabindex="100">{{ 'I forgot my password'|trans({}, 'TablerBundle') }}</a>
-                                        </span>
+                                        <a href="{{ path('tabler_password_reset'|tabler_route) }}" tabindex="100">{{ 'I forgot my password'|trans({}, 'TablerBundle') }}</a>
+                                    </span>
                                 {% endif %}
                             {% endblock %}
                         </label>
                         <div class="input-group input-group-flat">
-                            <input name="_password" type="password" tabindex="20" class="form-control" placeholder="{{ 'Password'|trans({}, 'TablerBundle') }}">
+                            <input id="password" name="_password" type="password" tabindex="20" class="form-control" placeholder="{{ 'Password'|trans({}, 'TablerBundle') }}">
                         </div>
                     </div>
                     {% block remember_me %}
@@ -68,7 +66,24 @@
                     {% block login_form_end %}{% endblock %}
                 </form>
             {% endblock %}
-
+            {% block login_social_auth %}
+                <div class="hr-text">{{ 'or'|trans({}, 'TablerBundle') }}</div>
+                <div class="card-body">
+                    <div class="row">
+                        <div class="col">
+                            <a href="#" class="btn btn-white w-100">
+                                <i class="icon fab fa-github text-github"></i> Github
+                            </a>
+                        </div>
+                        <div class="col">
+                            <a href="#" class="btn btn-white w-100">
+                                <i class="icon fab fa-twitter text-twitter"></i> Twitter
+                            </a>
+                        </div>
+                    </div>
+                </div>
+            {% endblock %}
+            
             {% block login_actions %}
                 {% block registration %}
                     {% if 'tabler_registration'|tabler_route != 'tabler_registration' %}
@@ -85,7 +100,7 @@
 
     <div class="col-12 col-lg-6 col-xl-8 d-none d-lg-block">
         {% block before_cover %}{% endblock %}
-        <div class="{% block cover_classes %}bg-cover h-100 min-vh-100{% endblock %}" style="{% block cover_style %}background-image: url(https://placehold.co/1000){% endblock %}"></div>
+        <div class="{% block cover_classes %}bg-cover h-100 min-vh-100{% endblock %}" style="{% block cover_style %}background-image: url({% block cover_url %}https://placehold.co/1000{% endblock %}){% endblock %}"></div>
         {% block after_cover %}{% endblock %}
     </div>
 </div>

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -58,6 +58,7 @@ class ConfigurationTest extends TestCase
                     'user_menu_condensed' => false,
                     'logo_url' => null,
                     'navbar_overlap' => false,
+                    'security_cover_url' => 'https://placehold.co/1000',
                 ],
                 'knp_menu' => [
                     'enable' => false,

--- a/tests/Helper/ContextHelperTest.php
+++ b/tests/Helper/ContextHelperTest.php
@@ -19,19 +19,27 @@ class ContextHelperTest extends TestCase
 {
     public function testOptions()
     {
-        $context = new ContextHelper([
+        $input = [
             'foo' => 'bar',
-        ]);
+            'security_cover_url' => 'https://placehold.co/1000',
+        ];
+
+        $context = new ContextHelper($input);
 
         $this->assertFalse($context->hasOption('test'));
         $this->assertNull($context->getOption('test'));
 
         $this->assertTrue($context->hasOption('foo'));
         $this->assertEquals('bar', $context->getOption('foo'));
-        $this->assertEquals(['foo' => 'bar'], $context->getOptions());
+        $this->assertEquals($input, $context->getOptions());
 
         $context->setOption('test', 'bla');
         $this->assertTrue($context->hasOption('test'));
         $this->assertEquals('bla', $context->getOption('test'));
+
+        $this->assertEquals('https://placehold.co/1000', $context->getSecurityCoverUrl());
+        $this->assertEquals('https://placehold.co/1000', $context->getOption('security_cover_url'));
+        $context->setSecurityCoverUrl('https://placehold.co/1234');
+        $this->assertEquals('https://placehold.co/1234', $context->getSecurityCoverUrl());
     }
 }


### PR DESCRIPTION
## Description
Add login cover page from Tabler : https://preview.tabler.io/sign-in-cover.html


<del>

⚠️ Many parts of the code is copy-pasta from `security.html.twig`.
The only "new" code is before the login form AND after.

As a twig "way to work", devs cannot override blocks inside of an embed/include..
How do you want to handle that duplicated code @kevinpapst?

</del>

Extended from `/security.html.twig`

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] I updated the documentation (see [here](https://github.com/kevinpapst/TablerBundle/tree/master/docs))
- [x] I agree that this code will be published under the [MIT license](https://github.com/kevinpapst/TablerBundle/blob/master/LICENSE)
