### PR TITLE
added method to configure translation domain

### DIFF
--- a/src/Model/MenuItemInterface.php
+++ b/src/Model/MenuItemInterface.php
@@ -17,6 +17,8 @@ interface MenuItemInterface
 
     public function getLabel(): ?string;
 
+    public function getTranslationDomain(): string;
+
     public function getRoute(): ?string;
 
     public function getRouteArgs(): array;

--- a/src/Model/MenuItemModel.php
+++ b/src/Model/MenuItemModel.php
@@ -24,6 +24,7 @@ class MenuItemModel implements MenuItemInterface
     private bool $isActive = false;
     private bool $divider = false;
     private bool $expanded = false;
+    private string $translationDomain = 'messages';
 
     public function __construct(
         string $identifier,
@@ -212,5 +213,15 @@ class MenuItemModel implements MenuItemInterface
     public function setExpanded(bool $expanded): void
     {
         $this->expanded = $expanded;
+    }
+
+    public function getTranslationDomain(): string
+    {
+        return $this->translationDomain;
+    }
+
+    public function setTranslationDomain(string $translationDomain): void
+    {
+        $this->translationDomain = $translationDomain;
     }
 }

--- a/templates/includes/menu.html.twig
+++ b/templates/includes/menu.html.twig
@@ -17,7 +17,7 @@
                         class="nav-link" href="{{ '/' in item.route ? item.route : (item.route is null ? '#' : path(item.route|tabler_route, item.routeArgs)) }}"
                     {% endif %}>
                     {{ _self.item_icon(item) }}
-                    <span class="nav-link-title">{{ item.label|trans }}</span>
+                    <span class="nav-link-title">{{ item.label|trans({}, item.translationDomain) }}</span>
                     {% if layout_type is same as 'horizontal' %}
                         {{ _self.item_badge(item) }}
                     {% endif %}
@@ -40,7 +40,7 @@
                                    data-bs-toggle="dropdown" data-bs-auto-close="{{ layout_type is same as "vertical" ? 'false' : 'outside' }}"
                                    aria-expanded="{{ layout_type is same as "vertical" }}">
                                     {{ _self.item_icon(child) }}
-                                    {{ child.label|trans }}
+                                    {{ child.label|trans({}, child.translationDomain) }}
                                     {{ _self.item_badge(child) }}
                                 </a>
                                 {{ _self.item_childs(child, layout_type) }}
@@ -64,7 +64,7 @@
         <a class="dropdown-item {{ child.isActive ? 'active':'' }}"
                 {%- if not child.hasChildren %} href="{{ '/' in child.route ? child.route : (child.route is null ? '#' : path(child.route|tabler_route, child.routeArgs)) }}"{% endif %}>
             {{ _self.item_icon(child) }}
-            {{ child.label|trans }}
+            {{ child.label|trans({}, child.translationDomain) }}
             {{ _self.item_badge(child) }}
         </a>
     {% endif %}


### PR DESCRIPTION
## Description

added method to configure translation domain

BC break: adds a new method to the `MenuItemInterface`.

If you are not using the built-in MenuItemModel, you have to update your code!

## Types of changes
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] I updated the documentation (see [here](https://github.com/kevinpapst/TablerBundle/tree/master/docs))
- [x] I agree that this code will be published under the [MIT license](https://github.com/kevinpapst/TablerBundle/blob/master/LICENSE)
