### PR TITLE
[Card] Add `.card-body` print condition

### DIFF
--- a/templates/embeds/card.html.twig
+++ b/templates/embeds/card.html.twig
@@ -21,7 +21,7 @@
 {% set _hasTitle            = title is not empty %}
 {% set _hasTools            = tools is not empty %}
 {% set _hasHeader           = header is not empty %}
-{% set _hasBody             = body is not empty or _force_body %}
+{% set _hasBody             = _use_body or body is not empty %}
 {% set _hasFooter           = _use_footer or footer is not empty %}
 
 {% import '@Tabler/components/buttons.html.twig' as button %}

--- a/templates/embeds/card.html.twig
+++ b/templates/embeds/card.html.twig
@@ -8,6 +8,7 @@
 {% set _collapsible         = collapsible ?? _collapsed %}
 {% set _footer_collapsible  = footer_collapsible ?? true %}
 {% set _use_footer          = use_footer ?? false %}
+{% set _force_body          = force_body ?? false %}
 
 {# Common blocks : Declared this way to use `is not empty` and prevent the `has already been rendered` form field twig error #}
 {% set header %}{% block box_header %}{% endblock %}{% endset %}
@@ -20,7 +21,7 @@
 {% set _hasTitle            = title is not empty %}
 {% set _hasTools            = tools is not empty %}
 {% set _hasHeader           = header is not empty %}
-{% set _hasBody             = body is not empty %}
+{% set _hasBody             = body is not empty or _force_body %}
 {% set _hasFooter           = _use_footer or footer is not empty %}
 
 {% import '@Tabler/components/buttons.html.twig' as button %}
@@ -59,9 +60,11 @@
 
     {# Body #}
     {% block box_body_before %}{% endblock %}
+    {% if _hasBody %}
     <div class="{% block box_type_class %}card-body {% endblock %}{% block box_body_class %}{% endblock %} {% if _fullsize %}p-0{% endif %} {% if _collapsible %} {{ _collapsible_class ~ (_collapsed ? ' collapse' : ' show') }} {% endif %}">
         {{ body|raw }}
     </div>
+    {% endif %}
     {% block box_body_after %}{% endblock %}
 
     {# Footer #}

--- a/templates/embeds/card.html.twig
+++ b/templates/embeds/card.html.twig
@@ -8,7 +8,7 @@
 {% set _collapsible         = collapsible ?? _collapsed %}
 {% set _footer_collapsible  = footer_collapsible ?? true %}
 {% set _use_footer          = use_footer ?? false %}
-{% set _use_body          = use_body ?? true %}
+{% set _use_body            = use_body ?? true %}
 
 {# Common blocks : Declared this way to use `is not empty` and prevent the `has already been rendered` form field twig error #}
 {% set header %}{% block box_header %}{% endblock %}{% endset %}

--- a/templates/embeds/card.html.twig
+++ b/templates/embeds/card.html.twig
@@ -8,7 +8,7 @@
 {% set _collapsible         = collapsible ?? _collapsed %}
 {% set _footer_collapsible  = footer_collapsible ?? true %}
 {% set _use_footer          = use_footer ?? false %}
-{% set _force_body          = force_body ?? true %}
+{% set _use_body          = use_body ?? true %}
 
 {# Common blocks : Declared this way to use `is not empty` and prevent the `has already been rendered` form field twig error #}
 {% set header %}{% block box_header %}{% endblock %}{% endset %}

--- a/templates/embeds/card.html.twig
+++ b/templates/embeds/card.html.twig
@@ -61,9 +61,9 @@
     {# Body #}
     {% block box_body_before %}{% endblock %}
     {% if _hasBody %}
-    <div class="{% block box_type_class %}card-body {% endblock %}{% block box_body_class %}{% endblock %} {% if _fullsize %}p-0{% endif %} {% if _collapsible %} {{ _collapsible_class ~ (_collapsed ? ' collapse' : ' show') }} {% endif %}">
-        {{ body|raw }}
-    </div>
+        <div class="{% block box_body_classes %}card-body {% block box_body_class %}{% endblock %}{% endblock %} {% if _fullsize %}p-0{% endif %} {% if _collapsible %} {{ _collapsible_class ~ (_collapsed ? ' collapse' : ' show') }} {% endif %}">
+            {{ body|raw }}
+        </div>
     {% endif %}
     {% block box_body_after %}{% endblock %}
 

--- a/templates/embeds/card.html.twig
+++ b/templates/embeds/card.html.twig
@@ -8,7 +8,7 @@
 {% set _collapsible         = collapsible ?? _collapsed %}
 {% set _footer_collapsible  = footer_collapsible ?? true %}
 {% set _use_footer          = use_footer ?? false %}
-{% set _force_body          = force_body ?? false %}
+{% set _force_body          = force_body ?? true %}
 
 {# Common blocks : Declared this way to use `is not empty` and prevent the `has already been rendered` form field twig error #}
 {% set header %}{% block box_header %}{% endblock %}{% endset %}


### PR DESCRIPTION
## Description

A Card with a fullsized table from Tabler should apparently not be inside `card-body`.


See here for Tabler demo: https://preview.tabler.io/tables.html (see `invoices` table)
![image](https://user-images.githubusercontent.com/25293190/229159686-72adf3fd-5ece-41c3-bd4b-f976167f4235.png)

With empty body and no padding (`fullsize` card template option) + Table inside card-body
![image](https://user-images.githubusercontent.com/25293190/229160159-acfdec59-0132-4076-aede-61b88554da98.png)

I've added condition to not always print this part.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] I updated the documentation (see [here](https://github.com/kevinpapst/TablerBundle/tree/master/docs))
- [x] I agree that this code will be published under the [MIT license](https://github.com/kevinpapst/TablerBundle/blob/master/LICENSE)
