### PR TITLE
allow collapse on complete card header

### DIFF
--- a/templates/embeds/card.html.twig
+++ b/templates/embeds/card.html.twig
@@ -38,7 +38,7 @@
     {# Header #}
     {% block box_header_before %}{% endblock %}
     {% if _hasTitle or _collapsible or _hasTools or _hasHeader %}
-        <div class="card-header {% block box_header_class %}{% endblock %}">
+        <div class="card-header {% block box_header_class %}{% endblock %}"{% if _collapsible %} data-bs-toggle="collapse" data-bs-target=".{{ _collapsible_class }}" data-bs-placement="top" title="{{ collapsible_title|default('Toggle visibility'|trans({}, 'TablerBundle')) }}"{% endif %}>
             {% if _hasHeader %}
                 {{ header|raw }}
             {% else %}


### PR DESCRIPTION
## Description

Customers mentioned, that it would be much more comfortable, if they could click the entire card header.

So not only the arrow icon, but also the entire title and whitespace in between:
<img width="692" alt="Bildschirmfoto 2023-05-30 um 17 06 40" src="https://github.com/kevinpapst/TablerBundle/assets/533162/97683a03-f73f-4191-8c0e-e68e5c341569">

I have to agree, they are not wrong.

WDYT @cavasinf ?

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] I updated the documentation (see [here](https://github.com/kevinpapst/TablerBundle/tree/master/docs))
- [x] I agree that this code will be published under the [MIT license](https://github.com/kevinpapst/TablerBundle/blob/master/LICENSE)
