### PR TITLE
[Accordion] Add bodyClasses & before & after

### DIFF
--- a/templates/components/accordion.html.twig
+++ b/templates/components/accordion.html.twig
@@ -14,6 +14,9 @@
             {% set _id_collapse = _id ~ '_collapse_' ~ loop.index %}
             {% set _item_title = item.title ?? '' %}
             {% set _item_body = item.body ?? '' %}
+            {% set _item_body_classes = item.bodyClasses ?? 'pt-0' %}
+            {% set _item_body_before = item.bodyBefore ?? '' %}
+            {% set _item_body_after = item.bodyAfter ?? '' %}
 
             {# Item Options #}
             {% set _item_open = item.options.open ?? false %}
@@ -32,9 +35,11 @@
 
                 <div id="{{ _id_collapse }}" {% if _always_open == false %}data-bs-parent="#{{ _id }}"{% endif %}
                      class="accordion-collapse collapse {% if _item_open %}show{% endif %} {{ _item_body_extraClass }}">
-                    <div class="accordion-body pt-0">
+                    {% if _raw %}{{ _item_body_before | raw }}{% else %}{{ _item_body_before }}{% endif %}
+                    <div class="accordion-body {{ _item_body_classes }}">
                         {% if _raw %}{{ _item_body | raw }}{% else %}{{ _item_body }}{% endif %}
                     </div>
+                    {% if _raw %}{{ _item_body_after | raw }}{% else %}{{ _item_body_after }}{% endif %}
                 </div>
             </div>
 


### PR DESCRIPTION
## Description
Allows an accordion item to be more customizable

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] I updated the documentation (see [here](https://github.com/kevinpapst/TablerBundle/tree/master/docs))
- [x] I agree that this code will be published under the [MIT license](https://github.com/kevinpapst/TablerBundle/blob/master/LICENSE)
