### PR TITLE
Version 1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,22 +10,21 @@
         }
     ],
     "require": {
-        "php": ">=7.4",
-        "symfony/asset": "^4.4 || ^5.4 || ^6.0",
-        "symfony/config": "^4.4 || ^5.4 || ^6.0",
-        "symfony/dependency-injection": "^4.4 || ^5.4 || ^6.0",
-        "symfony/event-dispatcher": "^4.4 || ^5.4 || ^6.0",
-        "symfony/http-foundation": "^4.4 || ^5.4 || ^6.0",
-        "symfony/http-kernel": "^4.4 || ^5.4 || ^6.0",
-        "symfony/options-resolver": "^4.4 || ^5.4 || ^6.0",
-        "symfony/security-core": "^4.4 || ^5.4 || ^6.0",
-        "symfony/translation": "^4.4 || ^5.4 || ^6.0",
-        "symfony/twig-bridge": "^4.4 || ^5.4 || ^6.0",
+        "php": "8.1.*||8.2.*",
+        "symfony/asset": "^6.0",
+        "symfony/config": "^6.0",
+        "symfony/dependency-injection": "^6.0",
+        "symfony/event-dispatcher": "^6.0",
+        "symfony/http-foundation": "^6.0",
+        "symfony/http-kernel": "^6.0",
+        "symfony/options-resolver": "^6.0",
+        "symfony/security-core": "^6.0",
+        "symfony/translation": "^6.0",
+        "symfony/twig-bridge": "^6.0",
         "twig/twig": "^3.0"
     },
     "require-dev": {
-        "phpspec/prophecy": "^1.6",
-        "symfony/framework-bundle" : "^4.4 || ^5.4 || ^6.0",
+        "symfony/framework-bundle" : "^6.0",
         "friendsofphp/php-cs-fixer": "^3.0",
         "phpunit/phpunit": "^9.0",
         "phpstan/phpstan": "^1.0",
@@ -49,8 +48,8 @@
     "scripts": {
         "tests": "vendor/bin/phpunit tests/",
         "phpstan": [
-            "vendor/bin/phpstan analyse src/ --level=5",
-            "vendor/bin/phpstan analyse -c tests/phpstan.neon tests/ --level=5"
+            "vendor/bin/phpstan analyse -c phpstan.neon src/",
+            "vendor/bin/phpstan analyse -c tests/phpstan.neon tests/"
         ],
         "codestyle": "vendor/bin/php-cs-fixer fix --dry-run --verbose --show-progress=none",
         "codestyle-fix": "vendor/bin/php-cs-fixer fix"

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -4,5 +4,6 @@ includes:
     - vendor/phpstan/phpstan-symfony/rules.neon
 
 parameters:
+    level: 9
     excludePaths:
         - %rootDir%/../../

--- a/src/DependencyInjection/TablerExtension.php
+++ b/src/DependencyInjection/TablerExtension.php
@@ -33,7 +33,7 @@ class TablerExtension extends Extension implements PrependExtensionInterface
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__ . '/../../config'));
         $loader->load('services.yml');
 
-        if ($options['knp_menu']['enable'] === true) {
+        if (\array_key_exists('knp_menu', $options) && \array_key_exists('enable', $options['knp_menu']) && $options['knp_menu']['enable'] === true) {
             $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__ . '/../../config/container'));
             $loader->load('knp-menu.yml');
         }
@@ -42,13 +42,13 @@ class TablerExtension extends Extension implements PrependExtensionInterface
     /**
      * Merge available configuration options, so they are all available for the ContextHelper.
      *
-     * @param array $config
-     * @return array
+     * @param array<string, mixed> $config
+     * @return array<string, array<string, mixed>>
      */
-    protected function getContextOptions(array $config = []): array
+    private function getContextOptions(array $config): array
     {
         $contextOptions = (array) ($config['options'] ?? []);
-        $contextOptions['knp_menu'] = (array) $config['knp_menu'];
+        $contextOptions['knp_menu'] = (array) ($config['knp_menu'] ?? []);
 
         return $contextOptions;
     }

--- a/src/Event/MenuEvent.php
+++ b/src/Event/MenuEvent.php
@@ -20,15 +20,10 @@ class MenuEvent extends ThemeEvent
     /**
      * @var MenuItemInterface[]
      */
-    private $menuRootItems = [];
-    /**
-     * @var Request
-     */
-    private $request;
+    private array $menuRootItems = [];
 
-    public function __construct(Request $request)
+    public function __construct(private Request $request)
     {
-        $this->request = $request;
     }
 
     public function getRequest(): Request

--- a/src/Event/NotificationEvent.php
+++ b/src/Event/NotificationEvent.php
@@ -16,7 +16,7 @@ class NotificationEvent extends ThemeEvent
     /**
      * @var array<NotificationInterface>
      */
-    private $notifications = [];
+    private array $notifications = [];
 
     /**
      * @param int|null $max

--- a/src/Event/UserDetailsEvent.php
+++ b/src/Event/UserDetailsEvent.php
@@ -17,15 +17,12 @@ use KevinPapst\TablerBundle\Model\UserInterface;
  */
 class UserDetailsEvent extends ThemeEvent
 {
-    /**
-     * @var UserInterface
-     */
-    private $user;
+    private ?UserInterface $user = null;
     /**
      * @var MenuItemInterface[]
      */
-    private $links = [];
-    private $showLogoutLink = true;
+    private array $links = [];
+    private bool $showLogoutLink = true;
 
     public function setUser(UserInterface $user): void
     {

--- a/src/Helper/ContextHelper.php
+++ b/src/Helper/ContextHelper.php
@@ -9,11 +9,19 @@
 
 namespace KevinPapst\TablerBundle\Helper;
 
+/**
+ * @extends \ArrayObject<string, mixed>
+ */
 class ContextHelper extends \ArrayObject
 {
     public function getLogoUrl(): ?string
     {
-        return $this->getOption('logo_url');
+        $logo = $this->getOption('logo_url');
+        if (\is_string($logo)) {
+            return $logo;
+        }
+
+        return null;
     }
 
     public function setLogoUrl(?string $logo): void
@@ -73,7 +81,12 @@ class ContextHelper extends \ArrayObject
 
     public function getAssetVersion(): string
     {
-        return (string) $this->getOption('asset_version');
+        $version = $this->getOption('asset_version');
+        if (\is_string($version)) {
+            return $version;
+        }
+
+        return '1.0';
     }
 
     public function setAssetVersion(string $assetVersion): void
@@ -113,7 +126,12 @@ class ContextHelper extends \ArrayObject
 
     public function getSecurityCoverUrl(): string
     {
-        return (string) $this->getOption('security_cover_url');
+        $cover = $this->getOption('security_cover_url');
+        if (\is_string($cover)) {
+            return $cover;
+        }
+
+        return '';
     }
 
     public function setSecurityCoverUrl(string $url): void
@@ -121,16 +139,15 @@ class ContextHelper extends \ArrayObject
         $this->setOption('security_cover_url', $url);
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     public function getOptions(): array
     {
         return $this->getArrayCopy();
     }
 
-    /**
-     * @param string $name
-     * @param mixed|null $value
-     */
-    public function setOption(string $name, $value): void
+    public function setOption(string $name, mixed $value): void
     {
         $this->offsetSet($name, $value);
     }
@@ -140,12 +157,7 @@ class ContextHelper extends \ArrayObject
         return $this->offsetExists($name);
     }
 
-    /**
-     * @param string $name
-     * @param mixed $default
-     * @return mixed|null
-     */
-    public function getOption(string $name, $default = null)
+    public function getOption(string $name, mixed $default = null): mixed
     {
         return $this->offsetExists($name) ? $this->offsetGet($name) : $default;
     }

--- a/src/Model/MenuItemInterface.php
+++ b/src/Model/MenuItemInterface.php
@@ -21,6 +21,9 @@ interface MenuItemInterface
 
     public function getRoute(): ?string;
 
+    /**
+     * @return array<string, mixed>
+     */
     public function getRouteArgs(): array;
 
     public function getIcon(): ?string;

--- a/src/Model/MenuItemModel.php
+++ b/src/Model/MenuItemModel.php
@@ -14,6 +14,7 @@ class MenuItemModel implements MenuItemInterface
     private string $identifier;
     private string $label;
     private ?string $route;
+    /** @var array<string, mixed> */
     private array $routeArgs;
     private ?string $icon;
     /** @var array<MenuItemInterface> */
@@ -26,6 +27,9 @@ class MenuItemModel implements MenuItemInterface
     private bool $expanded = false;
     private string $translationDomain = 'messages';
 
+    /**
+     * @param array<string, mixed> $routeArgs
+     */
     public function __construct(
         string $identifier,
         string $label,
@@ -78,9 +82,7 @@ class MenuItemModel implements MenuItemInterface
 
     public function setIsActive(bool $isActive): void
     {
-        if ($this->hasParent()) {
-            $this->getParent()->setIsActive($isActive);
-        }
+        $this->parent?->setIsActive($isActive);
 
         $this->isActive = $isActive;
     }
@@ -125,6 +127,9 @@ class MenuItemModel implements MenuItemInterface
         return $this->routeArgs;
     }
 
+    /**
+     * @param array<string, mixed> $routeArgs
+     */
     public function setRouteArgs(array $routeArgs): void
     {
         $this->routeArgs = $routeArgs;

--- a/src/Model/NotificationModel.php
+++ b/src/Model/NotificationModel.php
@@ -13,16 +13,10 @@ use KevinPapst\TablerBundle\Helper\Constants;
 
 class NotificationModel implements NotificationInterface
 {
-    private $id;
-    private $message;
-    private $type;
-    private $url;
+    private ?string $url = null;
 
-    public function __construct(string $id, string $message, string $type = Constants::TYPE_INFO)
+    public function __construct(private string $id, private string $message, private string $type = Constants::TYPE_INFO)
     {
-        $this->id = $id;
-        $this->message = $message;
-        $this->type = $type;
     }
 
     public function getIdentifier(): string

--- a/src/Model/UserInterface.php
+++ b/src/Model/UserInterface.php
@@ -13,23 +13,16 @@ interface UserInterface
 {
     /**
      * The user identifier for generating links.
-     *
-     * @return string
-     * @deprecated will be renamed to getUserIdentifier() once we raise the minimum SF version to 5
      */
-    public function getIdentifier(): string;
+    public function getUserIdentifier(): string;
 
     /**
      * Returns the display name (full name, email or whatever you want to use.
-     *
-     * @return string
      */
     public function getName(): string;
 
     /**
      * Additional title that can be displayed next to the user.
-     *
-     * @return string|null
      */
     public function getTitle(): ?string;
 
@@ -38,8 +31,6 @@ interface UserInterface
      *
      * You can change the avatar behaviour and return any other string, you just need
      * to overwrite the avatar component at templates/components/avatar_image.html.twig.
-     *
-     * @return string|null
      */
     public function getAvatar(): ?string;
 }

--- a/src/Model/UserModel.php
+++ b/src/Model/UserModel.php
@@ -11,27 +11,11 @@ namespace KevinPapst\TablerBundle\Model;
 
 final class UserModel implements UserInterface
 {
-    /**
-     * @var string
-     */
-    private $id;
-    /**
-     * @var string
-     */
-    private $name;
-    /**
-     * @var string|null
-     */
-    private $title;
-    /**
-     * @var string|null
-     */
-    private $avatar;
+    private ?string $title = null;
+    private ?string $avatar = null;
 
-    public function __construct(string $id, string $name)
+    public function __construct(private string $id, private string $name)
     {
-        $this->id = $id;
-        $this->name = $name;
     }
 
     public function getId(): string
@@ -74,7 +58,15 @@ final class UserModel implements UserInterface
         return $this->title;
     }
 
+    /**
+     * @deprecated use getUserIdentifier instead
+     */
     public function getIdentifier(): string
+    {
+        return $this->getUserIdentifier();
+    }
+
+    public function getUserIdentifier(): string
     {
         if (!empty($this->id)) {
             return $this->id;

--- a/src/TablerBundle.php
+++ b/src/TablerBundle.php
@@ -20,7 +20,7 @@ class TablerBundle extends Bundle
         return \dirname(__DIR__);
     }
 
-    public function build(ContainerBuilder $container)
+    public function build(ContainerBuilder $container): void
     {
         parent::build($container);
         $container->addCompilerPass(new TwigPass());

--- a/src/Twig/RuntimeExtension.php
+++ b/src/Twig/RuntimeExtension.php
@@ -20,29 +20,12 @@ use Twig\Extension\RuntimeExtensionInterface;
 
 final class RuntimeExtension implements RuntimeExtensionInterface
 {
-    private $eventDispatcher;
-    private $helper;
     /**
-     * @var array<string, string|null>
-     */
-    private $routes;
-    /**
-     * @var array<string, string>
-     */
-    private $icons;
-
-    /**
-     * @param EventDispatcherInterface $dispatcher
-     * @param ContextHelper $helper
      * @param array<string, string|null> $routes
      * @param array<string, string> $icons
      */
-    public function __construct(EventDispatcherInterface $dispatcher, ContextHelper $helper, array $routes, array $icons)
+    public function __construct(private EventDispatcherInterface $eventDispatcher, private ContextHelper $helper, private array $routes, private array $icons)
     {
-        $this->eventDispatcher = $dispatcher;
-        $this->helper = $helper;
-        $this->routes = $routes;
-        $this->icons = $icons;
     }
 
     public function getRouteByAlias(string $routeName): string

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -18,7 +18,7 @@ use Symfony\Component\Config\Definition\Processor;
  */
 class ConfigurationTest extends TestCase
 {
-    public function testDefaultConfiguration()
+    public function testDefaultConfiguration(): void
     {
         $configuration = new Configuration();
         $processor = new Processor();
@@ -32,7 +32,7 @@ class ConfigurationTest extends TestCase
         $this->assertEquals($expected, $processedConfig);
     }
 
-    public function testFullConfiguration()
+    public function testFullConfiguration(): void
     {
         $configuration = new Configuration();
         $processor = new Processor();
@@ -44,7 +44,10 @@ class ConfigurationTest extends TestCase
         $this->assertEquals($config['tabler'], $processedConfig);
     }
 
-    protected function getDefaultConfig()
+    /**
+     * @return array<string, array<string, array<string, mixed>>>
+     */
+    protected function getDefaultConfig(): array
     {
         return [
             'tabler' => [

--- a/tests/Event/NotificationEventTest.php
+++ b/tests/Event/NotificationEventTest.php
@@ -19,13 +19,13 @@ use PHPUnit\Framework\TestCase;
  */
 class NotificationEventTest extends TestCase
 {
-    public function testDefaults()
+    public function testDefaults(): void
     {
         $event = new NotificationEvent();
         $this->assertEquals(0, $event->getTotal());
     }
 
-    public function testTotalsAndReceiveLimitedSet()
+    public function testTotalsAndReceiveLimitedSet(): void
     {
         $event = new NotificationEvent();
         $notifications = $this->generateNbNotifications(7);
@@ -45,7 +45,7 @@ class NotificationEventTest extends TestCase
      * @param string $type
      * @return array|NotificationModel[]
      */
-    private function generateNbNotifications($number, $type = Constants::TYPE_INFO)
+    private function generateNbNotifications($number, $type = Constants::TYPE_INFO): array
     {
         $tasks = [];
         for ($i = 0; $i < $number; $i++) {

--- a/tests/Helper/ContextHelperTest.php
+++ b/tests/Helper/ContextHelperTest.php
@@ -17,7 +17,7 @@ use PHPUnit\Framework\TestCase;
  */
 class ContextHelperTest extends TestCase
 {
-    public function testOptions()
+    public function testOptions(): void
     {
         $input = [
             'foo' => 'bar',

--- a/tests/Model/NotificationModelTest.php
+++ b/tests/Model/NotificationModelTest.php
@@ -18,7 +18,7 @@ use PHPUnit\Framework\TestCase;
  */
 class NotificationModelTest extends TestCase
 {
-    public function testGetIdentifier()
+    public function testGetIdentifier(): void
     {
         $sut = new NotificationModel('foo', 'bar');
         $this->assertEquals('foo', $sut->getIdentifier());

--- a/tests/Model/UserModelTest.php
+++ b/tests/Model/UserModelTest.php
@@ -17,7 +17,7 @@ use PHPUnit\Framework\TestCase;
  */
 class UserModelTest extends TestCase
 {
-    public function testGetIdentifier()
+    public function testGetIdentifier(): void
     {
         $sut = new UserModel('foo', 'bar');
         $this->assertEquals('foo', $sut->getIdentifier());

--- a/tests/Twig/RuntimeExtensionTest.php
+++ b/tests/Twig/RuntimeExtensionTest.php
@@ -19,7 +19,11 @@ use Symfony\Component\EventDispatcher\EventDispatcher;
  */
 class RuntimeExtensionTest extends TestCase
 {
-    private function getSut(array $options = []): RuntimeExtension
+    /**
+     * @param array<string, mixed> $options
+     * @return RuntimeExtension
+     */
+    private function getSut(array $options): RuntimeExtension
     {
         $contextHelper = new ContextHelper();
         foreach ($options as $key => $value) {
@@ -41,16 +45,16 @@ class RuntimeExtensionTest extends TestCase
         return new RuntimeExtension($dispatcher, $contextHelper, $routes, $icons);
     }
 
-    public function testGetRouteByAlias()
+    public function testGetRouteByAlias(): void
     {
-        $sut = $this->getSut();
+        $sut = $this->getSut([]);
         $this->assertEquals('bar', $sut->getRouteByAlias('foo'));
         $this->assertEquals('hello', $sut->getRouteByAlias('hello'));
         // unknown routes will be returned as given
         $this->assertEquals('unknown-route', $sut->getRouteByAlias('unknown-route'));
     }
 
-    public function testBodyClass()
+    public function testBodyClass(): void
     {
         $sut = $this->getSut([]);
         $this->assertEquals('test', $sut->bodyClass('test'));
@@ -59,7 +63,7 @@ class RuntimeExtensionTest extends TestCase
         $this->assertEquals('test', $sut->bodyClass('test'));
     }
 
-    public function testTheme()
+    public function testTheme(): void
     {
         $sut = $this->getSut([]);
         $this->assertEquals('light', $sut->theme());
@@ -68,7 +72,7 @@ class RuntimeExtensionTest extends TestCase
         $this->assertEquals('dark', $sut->theme());
     }
 
-    public function testAssetVersion()
+    public function testAssetVersion(): void
     {
         $sut = $this->getSut(['asset_version' => '1234.56789']);
         $this->assertEquals('1234.56789', $sut->assetVersion());

--- a/tests/Twig/TablerExtensionTest.php
+++ b/tests/Twig/TablerExtensionTest.php
@@ -17,7 +17,7 @@ use PHPUnit\Framework\TestCase;
  */
 class TablerExtensionTest extends TestCase
 {
-    public function testGetFilters()
+    public function testGetFilters(): void
     {
         $expected = ['tabler_container', 'tabler_body', 'tabler_route', 'tabler_icon'];
         $sut = new TablerExtension();
@@ -28,7 +28,7 @@ class TablerExtensionTest extends TestCase
         $this->assertEquals($expected, $result);
     }
 
-    public function testGetFunctions()
+    public function testGetFunctions(): void
     {
         $expected = ['tabler_asset_version', 'tabler_icon', 'tabler_menu', 'tabler_notifications', 'tabler_theme', 'tabler_unique_id', 'tabler_user'];
         $sut = new TablerExtension();

--- a/tests/phpstan.neon
+++ b/tests/phpstan.neon
@@ -1,2 +1,5 @@
 includes:
     - ../vendor/phpstan/phpstan-phpunit/extension.neon
+
+parameters:
+    level: 9


### PR DESCRIPTION
## Description

- Symfony 6 only
- PHP 8 only
- Phpstan level 9
- Fixes deprecation with SF 6.3 about missing return types

Besides the obvious BC breaks due to added return types, there is one BC break that needs attention.

The `UserInterface` whose method changed from `getIdentifier()` to `getUserIdentifier()`.
As latter method is part of the Symfony User Interface, this shouldn't be an issue, as we target SF 6 only.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I updated the documentation (see [here](https://github.com/kevinpapst/TablerBundle/tree/master/docs))
- [x] I agree that this code will be published under the [MIT license](https://github.com/kevinpapst/TablerBundle/blob/master/LICENSE)
