### PR TITLE
[Status] Add `attr` option + deprecated non camelCase option

### DIFF
--- a/templates/components/status.html.twig
+++ b/templates/components/status.html.twig
@@ -20,7 +20,7 @@
         {{ utils.attr_to_html(_attr) }}
     >
         {% if _withDot %}
-            {{ status_dot({animated : _animated}) }}
+            {{ status_dot({color: _color, animated : _animated}) }}
         {% endif %}
         {{ text }}
     </span>

--- a/templates/components/status.html.twig
+++ b/templates/components/status.html.twig
@@ -14,17 +14,15 @@
     {% set _extraClass = options.extraClass ?? '' %}
     {% set _attr = options.attr ?? {} %}
 
-    {%- apply spaceless -%}
-        <span
-            class="status status-{{ _color }} {% if _lite %}status-lite{% endif %} {{ _extraClass }}"
-            {{ utils.attr_to_html(_attr) }}
-        >
-            {% if _withDot %}
-                {{ _self.status_dot({animated : _animated}) }}
-            {% endif %}
-            {{ text }}
-        </span>
-    {%- endapply -%}
+    <span
+        class="status status-{{ _color }} {% if _lite %}status-lite{% endif %} {{ _extraClass }}"
+        {{ utils.attr_to_html(_attr) }}
+    >
+        {% if _withDot %}
+            {{ _self.status_dot({animated : _animated}) }}
+        {% endif %}
+        {{ text }}
+    </span>
 {% endmacro %}
 
 {% macro status_dot(options) %}
@@ -35,10 +33,8 @@
     {% set _extraClass = options.extraClass ?? '' %}
     {% set _attr = options.attr ?? {} %}
 
-    {%- apply spaceless -%}
-        <span
-            class="status-dot {% if _animated %}status-dot-animated{% endif %} {% if _color is not null %}status-{{ _color }}{% endif %} {{ _extraClass }}"
-            {{ utils.attr_to_html(_attr) }}
-        ></span>
-    {%- endapply -%}
+    <span
+        class="status-dot {% if _animated %}status-dot-animated{% endif %} {% if _color is not null %}status-{{ _color }}{% endif %} {{ _extraClass }}"
+        {{ utils.attr_to_html(_attr) }}
+    ></span>
 {% endmacro %}

--- a/templates/components/status.html.twig
+++ b/templates/components/status.html.twig
@@ -1,5 +1,6 @@
 {% macro status(text, options) %}
     {% import '@Tabler/includes/utils.html.twig' as utils %}
+    {% import '@Tabler/components/status_dot.html.twig' as status_dot %}
 
     {% set _color = options.color ?? 'green' %}
     {% set _animated = (options.animated ?? true) is same as true %}
@@ -19,22 +20,8 @@
         {{ utils.attr_to_html(_attr) }}
     >
         {% if _withDot %}
-            {{ _self.status_dot({animated : _animated}) }}
+            {{ status_dot({animated : _animated}) }}
         {% endif %}
         {{ text }}
     </span>
-{% endmacro %}
-
-{% macro status_dot(options) %}
-    {% import '@Tabler/includes/utils.html.twig' as utils %}
-
-    {% set _color = options.color ?? null %}
-    {% set _animated = (options.animated ?? true) is same as true %}
-    {% set _extraClass = options.extraClass ?? '' %}
-    {% set _attr = options.attr ?? {} %}
-
-    <span
-        class="status-dot {% if _animated %}status-dot-animated{% endif %} {% if _color is not null %}status-{{ _color }}{% endif %} {{ _extraClass }}"
-        {{ utils.attr_to_html(_attr) }}
-    ></span>
 {% endmacro %}

--- a/templates/components/status.html.twig
+++ b/templates/components/status.html.twig
@@ -1,15 +1,28 @@
 {% macro status(text, options) %}
+    {% import '@Tabler/components/status.html.twig' as macro %}
+    {% import '@Tabler/includes/utils.html.twig' as utils %}
+
     {% set _color = options.color ?? 'green' %}
-    {% set _animated = options.animated ?? true %}
-    {% set _lite = options.lite is defined ? options.lite  : false %}
-    {% set _with_dot = options.with_dot is defined ? options.with_dot  : false %}
+    {% set _animated = (options.animated ?? true) is same as true %}
+    {% set _lite = (options.lite ?? false) is same as true %}
+    {% if options.with_dot is defined %}
+        {% deprecated 'with_dot option is deprecated, use withDot option instead!' %}
+        {% set _withDot = options.with_dot is same as true %}
+    {% else %}
+        {% set _withDot = (options.withDot ?? false) is same as true %}
+    {% endif %}
+
     {% set _extraClass = options.extraClass ?? '' %}
+    {% set _attr = options.attr ?? {} %}
 
     {%- apply spaceless -%}
-        <span class="status status-{{ _color }} {{ _lite ? 'status-lite' : '' }} {{ _extraClass }}">
-        {% if _with_dot %}
-            <span class="status-dot {{ _animated ? 'status-dot-animated' : '' }}"></span>
-        {% endif %}
+        <span
+            class="status status-{{ _color }} {% if _lite %}status-lite{% endif %} {{ _extraClass }}"
+            {{ utils.attr_to_html(_attr) }}
+        >
+            {% if _withDot %}
+                {{ macro.status_dot({animated : _animated}) }}
+            {% endif %}
             {{ text }}
         </span>
     {%- endapply -%}

--- a/templates/components/status.html.twig
+++ b/templates/components/status.html.twig
@@ -1,5 +1,4 @@
 {% macro status(text, options) %}
-    {% import '@Tabler/components/status.html.twig' as macro %}
     {% import '@Tabler/includes/utils.html.twig' as utils %}
 
     {% set _color = options.color ?? 'green' %}
@@ -21,7 +20,7 @@
             {{ utils.attr_to_html(_attr) }}
         >
             {% if _withDot %}
-                {{ macro.status_dot({animated : _animated}) }}
+                {{ _self.status_dot({animated : _animated}) }}
             {% endif %}
             {{ text }}
         </span>

--- a/templates/components/status.html.twig
+++ b/templates/components/status.html.twig
@@ -14,3 +14,19 @@
         </span>
     {%- endapply -%}
 {% endmacro %}
+
+{% macro status_dot(options) %}
+    {% import '@Tabler/includes/utils.html.twig' as utils %}
+
+    {% set _color = options.color ?? null %}
+    {% set _animated = (options.animated ?? true) is same as true %}
+    {% set _extraClass = options.extraClass ?? '' %}
+    {% set _attr = options.attr ?? {} %}
+
+    {%- apply spaceless -%}
+        <span
+            class="status-dot {% if _animated %}status-dot-animated{% endif %} {% if _color is not null %}status-{{ _color }}{% endif %} {{ _extraClass }}"
+            {{ utils.attr_to_html(_attr) }}
+        ></span>
+    {%- endapply -%}
+{% endmacro %}

--- a/templates/components/status_dot.html.twig
+++ b/templates/components/status_dot.html.twig
@@ -1,7 +1,13 @@
 {% macro status_dot(options) %}
-    {% set _color = options.color ?? 'green' %}
-    {% set _animated = options.animated ?? true %}
-    {% set _extraClass = options.extraClass ?? '' %}
+    {% import '@Tabler/includes/utils.html.twig' as utils %}
 
-    <span class="status-dot status-{{ _color }} {% if _animated %}status-dot-animated{% endif %}"></span>
+    {% set _color = options.color ?? 'green' %}
+    {% set _animated = (options.animated ?? true) is same as true %}
+    {% set _extraClass = options.extraClass ?? '' %}
+    {% set _attr = options.attr ?? {} %}
+
+    <span
+        class="status-dot {% if _animated %}status-dot-animated{% endif %} {% if _color is not null %}status-{{ _color }}{% endif %} {{ _extraClass }}"
+        {{ utils.attr_to_html(_attr) }}
+    ></span>
 {% endmacro %}

--- a/templates/components/status_indicator.html.twig
+++ b/templates/components/status_indicator.html.twig
@@ -7,7 +7,7 @@
     {% set _attr = options.attr ?? {} %}
 
     <span
-        class="status-indicator {% if _animated %}status-indicator-animated{% endif %} {{ 'status-'~_color }} {{ _extraClass }}"
+        class="status-indicator {% if _animated %}status-indicator-animated{% endif %} status-{{ _color }} {{ _extraClass }}"
         {{ utils.attr_to_html(_attr) }}
     >
       <span class="status-indicator-circle"></span>

--- a/templates/components/status_indicator.html.twig
+++ b/templates/components/status_indicator.html.twig
@@ -1,10 +1,15 @@
 {% macro status_indicator(options) %}
+    {% import '@Tabler/includes/utils.html.twig' as utils %}
 
     {% set _color = options.color ?? 'green' %}
-    {% set _animated = options.animated ?? true %}
+    {% set _animated = (options.animated ?? true) is same as true %}
     {% set _extraClass = options.extraClass ?? '' %}
+    {% set _attr = options.attr ?? {} %}
 
-    <span class="status-indicator {{ _animated ? 'status-indicator-animated' : '' }} {{ 'status-'~_color }} {{ _extraClass }}">
+    <span
+        class="status-indicator {% if _animated %}status-indicator-animated{% endif %} {{ 'status-'~_color }} {{ _extraClass }}"
+        {{ utils.attr_to_html(_attr) }}
+    >
       <span class="status-indicator-circle"></span>
       <span class="status-indicator-circle"></span>
       <span class="status-indicator-circle"></span>

--- a/templates/components/status_indicator.html.twig
+++ b/templates/components/status_indicator.html.twig
@@ -14,5 +14,4 @@
       <span class="status-indicator-circle"></span>
       <span class="status-indicator-circle"></span>
     </span>
-
 {% endmacro %}


### PR DESCRIPTION
## Description

- Deprecate non camelCase `with_dot` option
- Add safe `bool` check on options values
- ~Add `status_dot` component~
- add `attr` option to each component

### Usage
```twig
<div>
    {{ status('Not animated', {withDot : true, animated : false, color: 'blue'}) }}
    {{ status('Lite with dot', {withDot : true, color: 'red', lite: true}) }}
    {{ status('No dot', {color: 'green'}) }}
    {{ status('id', {attr: {id : 'status_id'}}) }}

    {{ status_dot() }}
    {{ status_dot({color : 'purple'}) }}
    {{ status_dot({color : 'red', animated : false}) }}
    {{ status_dot({attr: {id : 'status_dot_id'}}) }}

    {{ status_indicator() }}
    {{ status_indicator({color : 'orange'}) }}
    {{ status_indicator({color : 'red', animated : false}) }}
    {{ status_indicator({attr: {id : 'status_indicator_id'}}) }}
</div>
```

### Visual

![status](https://github.com/kevinpapst/TablerBundle/assets/25293190/0312d6fd-0a40-49b2-9c08-3ba2c664ab18)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] I updated the documentation (see [here](https://github.com/kevinpapst/TablerBundle/tree/master/docs))
- [x] I agree that this code will be published under the [MIT license](https://github.com/kevinpapst/TablerBundle/blob/master/LICENSE)
