### PR TITLE
[Vertical layout] Remove `data-bs-theme` from header

### DIFF
--- a/templates/layout-vertical.html.twig
+++ b/templates/layout-vertical.html.twig
@@ -55,7 +55,7 @@ Enjoy your theme!
 
     {% block header %}
         {% if not tabler_bundle.isCondensedNavbar() %}
-            <header id="{% block header_id %}{% endblock %}" class="navbar navbar-expand-md d-none d-lg-flex d-print-none" data-bs-theme="{{ tabler_bundle.isHeaderDark() or tabler_bundle.isDarkMode() ? 'dark' : 'light' }}">
+            <header id="{% block header_id %}{% endblock %}" class="navbar navbar-expand-md d-none d-lg-flex d-print-none">
                 <div class="{{ ''|tabler_container }}">
                     <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbar-menu">
                         <span class="navbar-toggler-icon"></span>


### PR DESCRIPTION
## Description
This fixes code/logic that is not in Tabler today. 
See `<header>` at https://preview.tabler.io/layout-combo.html

It ends up as a bug when you want to redefine the primary color:

As it is today:
![image](https://github.com/kevinpapst/TablerBundle/assets/25293190/197cad21-eb47-432f-9209-604dab448965)

-------

How it should be (as Tabler demo):
![image](https://github.com/kevinpapst/TablerBundle/assets/25293190/dddb40a4-5513-4c28-a705-1eb2d230b1fd)

Works as expected in mobile view:
![image](https://github.com/kevinpapst/TablerBundle/assets/25293190/0bc405f7-182f-43bf-b499-a68a5336dc18)



## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] I updated the documentation (see [here](https://github.com/kevinpapst/TablerBundle/tree/master/docs))
- [x] I agree that this code will be published under the [MIT license](https://github.com/kevinpapst/TablerBundle/blob/master/LICENSE)
