### PR TITLE
Make models fluent (minor change)

### DIFF
--- a/docs/menu.md
+++ b/docs/menu.md
@@ -58,7 +58,13 @@ class MenuBuilderSubscriber implements EventSubscriberInterface
         $blog->addChild(
             new MenuItemModel('ChildOneItemId', 'ChildOneDisplayName', 'child_1_route', [], 'fas fa-rss-square')
         )->addChild(
-            new MenuItemModel('ChildTwoItemId', 'ChildTwoDisplayName', 'child_2_route')
+            ## Use flkuence if u want to
+            (new MenuItemModel('ChildTwoItemId', 'ChildTwoDisplayName', 'child_2_route'))
+                ->setRouteArgs([
+                    'user' => $user
+                ])
+                ->setIsActive(true)
+                ->setIcon('assets/icon.gif')
         );
         
         $event->addItem($blog);

--- a/src/Model/MenuItemModel.php
+++ b/src/Model/MenuItemModel.php
@@ -55,9 +55,10 @@ class MenuItemModel implements MenuItemInterface
     /**
      * @param array<MenuItemInterface> $children
      */
-    public function setChildren(array $children): void
+    public function setChildren(array $children): self
     {
         $this->children = $children;
+        return $this;
     }
 
     public function getIcon(): ?string
@@ -65,9 +66,10 @@ class MenuItemModel implements MenuItemInterface
         return $this->icon;
     }
 
-    public function setIcon(string $icon): void
+    public function setIcon(string $icon): self
     {
         $this->icon = $icon;
+        return $this;
     }
 
     public function getIdentifier(): string
@@ -80,11 +82,12 @@ class MenuItemModel implements MenuItemInterface
         return $this->isActive;
     }
 
-    public function setIsActive(bool $isActive): void
+    public function setIsActive(bool $isActive): self
     {
         $this->parent?->setIsActive($isActive);
 
         $this->isActive = $isActive;
+        return $this;
     }
 
     public function hasParent(): bool
@@ -97,9 +100,10 @@ class MenuItemModel implements MenuItemInterface
         return $this->parent;
     }
 
-    public function setParent(MenuItemInterface $parent): void
+    public function setParent(MenuItemInterface $parent): self
     {
         $this->parent = $parent;
+        return $this;
     }
 
     public function getLabel(): string
@@ -107,9 +111,10 @@ class MenuItemModel implements MenuItemInterface
         return $this->label;
     }
 
-    public function setLabel(string $label): void
+    public function setLabel(string $label): self
     {
         $this->label = $label;
+        return $this;
     }
 
     public function getRoute(): ?string
@@ -117,9 +122,10 @@ class MenuItemModel implements MenuItemInterface
         return $this->route;
     }
 
-    public function setRoute(?string $route): void
+    public function setRoute(?string $route): self
     {
         $this->route = $route;
+        return $this;
     }
 
     public function getRouteArgs(): array
@@ -130,9 +136,10 @@ class MenuItemModel implements MenuItemInterface
     /**
      * @param array<string, mixed> $routeArgs
      */
-    public function setRouteArgs(array $routeArgs): void
+    public function setRouteArgs(array $routeArgs): self
     {
         $this->routeArgs = $routeArgs;
+        return $this;
     }
 
     public function hasChildren(): bool
@@ -140,17 +147,19 @@ class MenuItemModel implements MenuItemInterface
         return \count($this->children) > 0;
     }
 
-    public function addChild(MenuItemInterface $child): void
+    public function addChild(MenuItemInterface $child): self
     {
         $child->setParent($this);
         $this->children[] = $child;
+        return $this;
     }
 
-    public function removeChild(MenuItemInterface $child): void
+    public function removeChild(MenuItemInterface $child): self
     {
         if (false !== ($key = array_search($child, $this->children))) {
             unset($this->children[$key]);
         }
+        return $this;
     }
 
     public function getActiveChild(): ?MenuItemInterface
@@ -174,14 +183,16 @@ class MenuItemModel implements MenuItemInterface
         return $this->isActive;
     }
 
-    public function setBadge(?string $badge): void
+    public function setBadge(?string $badge): self
     {
         $this->badge = $badge;
+        return $this;
     }
 
-    public function setBadgeColor(?string $badgeColor): void
+    public function setBadgeColor(?string $badgeColor): self
     {
         $this->badgeColor = $badgeColor;
+        return $this;
     }
 
     public function getBadge(): ?string
@@ -199,9 +210,10 @@ class MenuItemModel implements MenuItemInterface
         return $this->divider;
     }
 
-    public function setDivider(bool $divider): void
+    public function setDivider(bool $divider): self
     {
         $this->divider = $divider;
+        return $this;
     }
 
     public function isExpanded(): bool
@@ -213,11 +225,12 @@ class MenuItemModel implements MenuItemInterface
      * Allows to manually expand menus in vertical navigation.
      *
      * @param bool $expanded
-     * @return void
+     * @return self
      */
-    public function setExpanded(bool $expanded): void
+    public function setExpanded(bool $expanded): self
     {
         $this->expanded = $expanded;
+        return $this;
     }
 
     public function getTranslationDomain(): string
@@ -225,8 +238,9 @@ class MenuItemModel implements MenuItemInterface
         return $this->translationDomain;
     }
 
-    public function setTranslationDomain(string $translationDomain): void
+    public function setTranslationDomain(string $translationDomain): self
     {
         $this->translationDomain = $translationDomain;
+        return $this;
     }
 }

--- a/src/Model/NotificationModel.php
+++ b/src/Model/NotificationModel.php
@@ -38,9 +38,10 @@ class NotificationModel implements NotificationV2Interface
         return $this->url;
     }
 
-    public function setUrl(?string $url): void
+    public function setUrl(?string $url): self
     {
         $this->url = $url;
+        return $this;
     }
 
     public function isActive(): bool
@@ -48,9 +49,10 @@ class NotificationModel implements NotificationV2Interface
         return $this->active;
     }
 
-    public function setActive(bool $active): void
+    public function setActive(bool $active): self
     {
         $this->active = $active;
+        return $this;
     }
 
     public function isDisabled(): bool
@@ -58,9 +60,10 @@ class NotificationModel implements NotificationV2Interface
         return $this->disabled;
     }
 
-    public function setDisabled(bool $disabled): void
+    public function setDisabled(bool $disabled): self
     {
         $this->disabled = $disabled;
+        return $this;
     }
 
     public function isWithBadge(): bool
@@ -68,9 +71,10 @@ class NotificationModel implements NotificationV2Interface
         return $this->withBadge;
     }
 
-    public function setWithBadge(bool $withBadge): void
+    public function setWithBadge(bool $withBadge): self
     {
         $this->withBadge = $withBadge;
+        return $this;
     }
 
     public function isBadgeAnimated(): bool
@@ -78,9 +82,10 @@ class NotificationModel implements NotificationV2Interface
         return $this->badgeAnimated;
     }
 
-    public function setBadgeAnimated(bool $badgeAnimated): void
+    public function setBadgeAnimated(bool $badgeAnimated): self
     {
         $this->badgeAnimated = $badgeAnimated;
+        return $this;
     }
 
     public function isHtml(): bool
@@ -88,9 +93,10 @@ class NotificationModel implements NotificationV2Interface
         return $this->html;
     }
 
-    public function setHtml(bool $html): void
+    public function setHtml(bool $html): self
     {
         $this->html = $html;
+        return $this;
     }
 
     public function getMessage(): string
@@ -98,9 +104,10 @@ class NotificationModel implements NotificationV2Interface
         return $this->message;
     }
 
-    public function setMessage(string $message): void
+    public function setMessage(string $message): self
     {
         $this->message = $message;
+        return $this;
     }
 
     public function getType(): string
@@ -108,8 +115,9 @@ class NotificationModel implements NotificationV2Interface
         return $this->type;
     }
 
-    public function setType(string $type): void
+    public function setType(string $type): self
     {
         $this->type = $type;
+        return $this;
     }
 }

--- a/src/Model/UserModel.php
+++ b/src/Model/UserModel.php
@@ -23,14 +23,16 @@ final class UserModel implements UserInterface
         return $this->id;
     }
 
-    public function setId(string $id): void
+    public function setId(string $id): self
     {
         $this->id = $id;
+        return $this;
     }
 
-    public function setAvatar(string $avatar): void
+    public function setAvatar(string $avatar): self
     {
         $this->avatar = $avatar;
+        return $this;
     }
 
     public function getAvatar(): ?string
@@ -38,9 +40,10 @@ final class UserModel implements UserInterface
         return $this->avatar;
     }
 
-    public function setName(string $name): void
+    public function setName(string $name): self
     {
         $this->name = $name;
+        return $this;
     }
 
     public function getName(): string
@@ -48,9 +51,10 @@ final class UserModel implements UserInterface
         return $this->name;
     }
 
-    public function setTitle(string $title): void
+    public function setTitle(string $title): self
     {
         $this->title = $title;
+        return $this;
     }
 
     public function getTitle(): ?string


### PR DESCRIPTION
## Description
The pull request add the Fluent pattern to the basic models. It should break nothing because void return types are exchenged to self. There can't be anybody how is checking his return types to void. Makes no sense. Fluent gives only a add.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I updated the documentation (see [here](https://github.com/kevinpapst/TablerBundle/tree/master/docs))
- [x] I agree that this code will be published under the [MIT license]https://github.com/kevinpapst/TablerBundle/blob/master/LICENSE)

It changes nothing to current usage but open a fluent usage of the models. You can concat the set function in one call.