### PR TITLE
Fix Twig 3.15 deprecation on ?? usage

### DIFF
--- a/templates/components/dropdown.html.twig
+++ b/templates/components/dropdown.html.twig
@@ -26,7 +26,7 @@
             {% set _attr = item.attr ?? {} %}
 
             {% if _badge.text is defined or _badge.class is defined %}
-                {% set badge = badgeMacro(_badge.text ?? '', _badge.class ?? '' ~ ' ms-auto') %}
+                {% set badge = badgeMacro(_badge.text ?? '', (_badge.class ?? '') ~ ' ms-auto') %}
             {% else %}
                 {% set badge = '' %}
             {% endif %}


### PR DESCRIPTION
Fix the deprecation `Deprecated: Since twig/twig 3.15: Add explicit parentheses around the "??" binary operator to avoid behavior change in the next major version as its precedence will change in "@Tabler/components/dropdown.html.twig" at line 29. `

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] I agree that this code will be published under the [MIT license](https://github.com/kevinpapst/TablerBundle/blob/master/LICENSE)
