### PR TITLE
Use non-deprecated Extension class

### DIFF
--- a/src/DependencyInjection/TablerExtension.php
+++ b/src/DependencyInjection/TablerExtension.php
@@ -11,9 +11,9 @@ namespace KevinPapst\TablerBundle\DependencyInjection;
 
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 class TablerExtension extends Extension implements PrependExtensionInterface
 {


### PR DESCRIPTION
## Description
This solves the deprecation reported when running with Symfony v7.2:

> The "Symfony\Component\HttpKernel\DependencyInjection\Extension" class is considered internal since Symfony 7.1, to be deprecated in 8.1; use Symfony\Component\DependencyInjection\Extension\Extension instead. It may change without further notice. You should not use it from "KevinPapst\TablerBundle\DependencyInjection\TablerExtension".


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] I updated the documentation (see [here](https://github.com/kevinpapst/TablerBundle/tree/master/docs))
- [x] I agree that this code will be published under the [MIT license](https://github.com/kevinpapst/TablerBundle/blob/master/LICENSE)


See as an example: https://github.com/hwi/HWIOAuthBundle/pull/2005