### PR TITLE
Add more layout flexibility

### DIFF
--- a/templates/layout-horizontal.html.twig
+++ b/templates/layout-horizontal.html.twig
@@ -94,7 +94,7 @@ Enjoy your theme!
                                             {% block page_pretitle %}Overview{% endblock %}
                                         </div>
                                     {% endblock %}
-                                    <h2 class="page-title">
+                                    <h2 class="page-title{% if tabler_bundle.isNavbarOverlapping() %} text-white{% endif %}">
                                         {% block page_title %}Dashboard{% endblock %}
                                     </h2>
                                     {% block page_subtitle %}

--- a/templates/layout-horizontal.html.twig
+++ b/templates/layout-horizontal.html.twig
@@ -80,70 +80,74 @@ Enjoy your theme!
     {% endblock %}
     {# *************************** #}
 
-    <div id="{% block page_wrapper_id %}{% endblock %}" class="page-wrapper">
-        {% block page_header %}
-            <div class="{{ ''|tabler_container }}">
-                {# Page title #}
-                <div id="{% block page_header_id %}{% endblock %}" class="page-header d-print-none">
-                    <div class="row align-items-center">
-                        <div class="col">
-                            {% block page_intro %}
-                                {% block breadcrumb %}
-                                    <div class="page-pretitle">
-                                        {% block page_pretitle %}Overview{% endblock %}
+    {% block page_wrapper %}
+        <div id="{% block page_wrapper_id %}{% endblock %}" class="page-wrapper {% block page_wrapper_class %}{% endblock %}">
+            {% block page_header %}
+                <div class="{{ ''|tabler_container }}">
+                    {# Page title #}
+                    <div id="{% block page_header_id %}{% endblock %}" class="page-header d-print-none {% block page_header_class %}{% endblock %}">
+                        <div class="row align-items-center">
+                            <div class="col">
+                                {% block page_intro %}
+                                    {% block breadcrumb %}
+                                        <div class="page-pretitle">
+                                            {% block page_pretitle %}Overview{% endblock %}
+                                        </div>
+                                    {% endblock %}
+                                    <h2 class="page-title">
+                                        {% block page_title %}Dashboard{% endblock %}
+                                    </h2>
+                                    {% block page_subtitle %}
+                                        <div class="text-body-secondary mt-1">
+                                            1-10 of 100
+                                        </div>
+                                    {% endblock %}
+                                {% endblock %}
+                            </div>
+                            <div class="{% block page_actions_class %}col-auto ms-auto d-print-none{% endblock %}">
+                                {% block page_actions %}
+                                    <div class="btn-list">
+                                        <a href="#" class="btn btn-white">
+                                            New view
+                                        </a>
+                                        <a href="#" class="btn btn-primary d-none d-sm-inline-block">
+                                            Create new report
+                                        </a>
                                     </div>
                                 {% endblock %}
-                                <h2 class="page-title{% if tabler_bundle.isNavbarOverlapping() %} text-white{% endif %}">
-                                    {% block page_title %}Dashboard{% endblock %}
-                                </h2>
-                                {% block page_subtitle %}
-                                    <div class="text-body-secondary mt-1">
-                                        1-10 of 100
-                                    </div>
-                                {% endblock %}
-                            {% endblock %}
-                        </div>
-                        <div class="{% block page_actions_class %}col-auto ms-auto d-print-none{% endblock %}">
-                            {% block page_actions %}
-                                <div class="btn-list">
-                                    <a href="#" class="btn btn-white">
-                                        New view
-                                    </a>
-                                    <a href="#" class="btn btn-primary d-none d-sm-inline-block">
-                                        Create new report
-                                    </a>
-                                </div>
-                            {% endblock %}
+                            </div>
                         </div>
                     </div>
                 </div>
-            </div>
-        {% endblock %}
+            {% endblock %}
 
-        <div class="page-body">
-            <div class="{{ ''|tabler_container }}">
-                <div class="row row-cards">
-                    {% block page_content_before %}{% endblock %}
+            {% block page_body %}
+                <div class="page-body">
+                    <div class="{{ ''|tabler_container }}">
+                        <div class="row row-cards">
+                            {% block page_content_before %}{% endblock %}
 
-                    <section id="{% block page_content_id %}{% endblock %}" class="{% block page_content_class %}content{% endblock %}">
-                        {% block page_content_start %}{{ include('@Tabler/includes/flash_messages.html.twig') }}{% endblock %}
-                        {% block page_content %}{% endblock %}
-                        {% block page_content_end %}{% endblock %}
-                    </section>
+                            <section id="{% block page_content_id %}{% endblock %}" class="{% block page_content_class %}content{% endblock %}">
+                                {% block page_content_start %}{{ include('@Tabler/includes/flash_messages.html.twig') }}{% endblock %}
+                                {% block page_content %}{% endblock %}
+                                {% block page_content_end %}{% endblock %}
+                            </section>
 
-                    {% block page_content_after %}{% endblock %}
+                            {% block page_content_after %}{% endblock %}
+                        </div>
+                    </div>
                 </div>
-            </div>
+            {% endblock %}
+
+            {% block footer %}
+                <footer id="{% block footer_id %}{% endblock %}" class="footer footer-transparent d-print-none {% block footer_class %}{% endblock %}">
+                    <div class="{{ ''|tabler_container }}">
+                        {% include '@Tabler/includes/footer.html.twig' %}
+                    </div>
+                </footer>
+            {% endblock %}
         </div>
-
-        {% block footer %}
-            <footer id="{% block footer_id %}{% endblock %}" class="footer footer-transparent d-print-none">
-                <div class="{{ ''|tabler_container }}">
-                    {% include '@Tabler/includes/footer.html.twig' %}
-                </div>
-            </footer>
-        {% endblock %}
-    </div>
+    {% endblock %}
 </div>
 
 {% block javascripts %}

--- a/templates/layout-vertical.html.twig
+++ b/templates/layout-vertical.html.twig
@@ -76,70 +76,74 @@ Enjoy your theme!
     {% endblock %}
     {# *************************** #}
 
-    <div id="{% block page_wrapper_id %}{% endblock %}" class="page-wrapper">
-        {% block page_header %}
-            <div class="{{ ''|tabler_container }}">
-                {# Page title #}
-                <div id="{% block page_header_id %}{% endblock %}" class="page-header d-print-none">
-                    <div class="row align-items-center">
-                        <div class="col">
-                        {% block page_intro %}
-                            {% block breadcrumb %}
-                                <div class="page-pretitle">
-                                    {% block page_pretitle %}Overview{% endblock %}
-                                </div>
+    {% block page_wrapper %}
+        <div id="{% block page_wrapper_id %}{% endblock %}" class="page-wrapper {% block page_wrapper_class %}{% endblock %}">
+            {% block page_header %}
+                <div class="{{ ''|tabler_container }}">
+                    {# Page title #}
+                    <div id="{% block page_header_id %}{% endblock %}" class="page-header d-print-none {% block page_header_class %}{% endblock %}">
+                        <div class="row align-items-center">
+                            <div class="col">
+                            {% block page_intro %}
+                                {% block breadcrumb %}
+                                    <div class="page-pretitle">
+                                        {% block page_pretitle %}Overview{% endblock %}
+                                    </div>
+                                {% endblock %}
+                                <h2 class="page-title">
+                                    {% block page_title %}Dashboard{% endblock %}
+                                </h2>
+                                {% block page_subtitle %}
+                                    <div class="text-body-secondary mt-1">
+                                        1-10 of 100
+                                    </div>
+                                {% endblock %}
                             {% endblock %}
-                            <h2 class="page-title">
-                                {% block page_title %}Dashboard{% endblock %}
-                            </h2>
-                            {% block page_subtitle %}
-                                <div class="text-body-secondary mt-1">
-                                    1-10 of 100
-                                </div>
-                            {% endblock %}
-                        {% endblock %}
-                        </div>
-                        <div class="{% block page_actions_class %}col-auto ms-auto d-print-none{% endblock %}">
-                            {% block page_actions %}
-                                <div class="btn-list">
-                                    <a href="#" class="btn btn-white">
-                                        New view
-                                    </a>
-                                    <a href="#" class="btn btn-primary d-none d-sm-inline-block">
-                                        Create new report
-                                    </a>
-                                </div>
-                            {% endblock %}
+                            </div>
+                            <div class="{% block page_actions_class %}col-auto ms-auto d-print-none{% endblock %}">
+                                {% block page_actions %}
+                                    <div class="btn-list">
+                                        <a href="#" class="btn btn-white">
+                                            New view
+                                        </a>
+                                        <a href="#" class="btn btn-primary d-none d-sm-inline-block">
+                                            Create new report
+                                        </a>
+                                    </div>
+                                {% endblock %}
+                            </div>
                         </div>
                     </div>
                 </div>
-            </div>
-        {% endblock %}
+            {% endblock %}
 
-        <div class="page-body">
-            <div class="{{ ''|tabler_container }}">
-                <div class="row row-cards">
-                    {% block page_content_before %}{% endblock %}
+            {% block page_body %}
+                <div class="page-body">
+                    <div class="{{ ''|tabler_container }}">
+                        <div class="row row-cards">
+                            {% block page_content_before %}{% endblock %}
 
-                    <section id="{% block page_content_id %}{% endblock %}" class="{% block page_content_class %}content{% endblock %}">
-                        {% block page_content_start %}{{ include('@Tabler/includes/flash_messages.html.twig') }}{% endblock %}
-                        {% block page_content %}{% endblock %}
-                        {% block page_content_end %}{% endblock %}
-                    </section>
+                            <section id="{% block page_content_id %}{% endblock %}" class="{% block page_content_class %}content{% endblock %}">
+                                {% block page_content_start %}{{ include('@Tabler/includes/flash_messages.html.twig') }}{% endblock %}
+                                {% block page_content %}{% endblock %}
+                                {% block page_content_end %}{% endblock %}
+                            </section>
 
-                    {% block page_content_after %}{% endblock %}
+                            {% block page_content_after %}{% endblock %}
+                        </div>
+                    </div>
                 </div>
-            </div>
+            {% endblock %}
+
+            {% block footer %}
+                <footer id="{% block footer_id %}{% endblock %}" class="footer footer-transparent d-print-none {% block footer_class %}{% endblock %}">
+                    <div class="{{ ''|tabler_container }}">
+                        {% include '@Tabler/includes/footer.html.twig' %}
+                    </div>
+                </footer>
+            {% endblock %}
         </div>
-
-        {% block footer %}
-            <footer id="{% block footer_id %}{% endblock %}" class="footer footer-transparent d-print-none">
-                <div class="{{ ''|tabler_container }}">
-                    {% include '@Tabler/includes/footer.html.twig' %}
-                </div>
-            </footer>
-        {% endblock %}
-    </div>
+    {% endblock %}
 </div>
 
 {% block javascripts %}


### PR DESCRIPTION
## Description
In case we want to replicate the [Tabler map-fullsize](https://preview.tabler.io/map-fullsize.html),  
we need to override the entire `page-body` and add a class to the `page-wrapper`

This can now be done as follows:
```twig
{% extends '@Tabler/layout-vertical.html.twig' %}

{% block page_wrapper_class %}page-wrapper-full{% endblock %}
{% block page_header %}{% endblock %}
{% block page_body %}
    <div class="page-body">
        <div
                class="map flex-fill"
        ></div>
    </div>
{% endblock %}
{% block footer %}{% endblock %}
```

| Vertical| Horizontal|
|--------|--------|
| ![vert](https://github.com/user-attachments/assets/6a65542c-db30-42f4-bd61-77b49bcae797)| ![horz](https://github.com/user-attachments/assets/6c1860de-2db8-4d6f-b5cc-707cf6eeb8cf)| 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] I updated the documentation (see [here](https://github.com/kevinpapst/TablerBundle/tree/master/docs))
- [x] I agree that this code will be published under the [MIT license](https://github.com/kevinpapst/TablerBundle/blob/master/LICENSE)
