### PR TITLE
[dropdown] Add `parent` item type

### DIFF
--- a/docs/components-dropdown.md
+++ b/docs/components-dropdown.md
@@ -28,6 +28,13 @@ See Tabler documentation at https://preview.tabler.io/dropdowns.html
 | extraClass | Add custom class to the item                                                       |      `string`      | _empty string_ |
 |    attr    | Custom HTML attributes to add to the item                                          |      `Object`      |      `{}`      |
 
+##### Item type `parent`
+| Parameter | Description                                                                             |        Type        |  Default  |
+|:---------:|-----------------------------------------------------------------------------------------|:------------------:|:---------:|
+|   type    | `parent`                                                                                |      `string`      | `parent`  |
+| autoClose | See [autoClose option](https://getbootstrap.com/docs/5.2/components/dropdowns/#options) | `boolean / string` | `outside` |
+| children  | Array of the nested [items](#Item)                                                      |      `array`       |   `[]`    |
+
 ##### Item Options
 |    Parameter    | Description                      |   Type    |    Default     |
 |:---------------:|----------------------------------|:---------:|:--------------:|
@@ -128,6 +135,24 @@ See Tabler documentation at https://preview.tabler.io/dropdowns.html
     {
         title: 'Firstname Lastname',
         html: '<span class="avatar avatar-xs rounded me-2">FL</span>'
+    },
+    {
+        type: 'divider',
+    },
+    {
+        type: 'parent',
+        title: 'Parent',
+        children : [
+            {
+                title: 'Child 1',
+            },
+            {
+                title: 'Child 2',
+            },
+            {
+                title: 'Child 3',
+            },
+        ],
     },
     {
         type: 'divider',

--- a/templates/components/dropdown.html.twig
+++ b/templates/components/dropdown.html.twig
@@ -50,6 +50,15 @@
                         {{ _html | raw }}
                     </div>
                 {% endif %}
+            {% elseif _type is same as 'parent' %}
+                {% set _children = item.children ?? [] %}
+                {% set _autoClose = item.autoClose ?? 'outside' %}
+                <div class="dropend">
+                    <a class="dropdown-item dropdown-toggle" data-bs-toggle="dropdown" data-bs-auto-close="{{ _autoClose }}" role="button">
+                        {{ _title }}
+                    </a>
+                    {{ _self.dropdown(_children) }}
+                </div>
             {% else %}
                 {% set classes = 'dropdown-item ' ~ (_disabled ? 'disabled ' : '') ~ (_active ? 'active ' : '') ~ _extraClass %}
                 {% if _type is same as 'link' %}

--- a/templates/components/dropdown.html.twig
+++ b/templates/components/dropdown.html.twig
@@ -52,7 +52,15 @@
                 {% endif %}
             {% elseif _type is same as 'parent' %}
                 {% set _children = item.children ?? [] %}
-                {% set _autoClose = item.autoClose ?? 'outside' %}
+                {% if item.autoClose is not defined %}
+                    {% set _autoClose = 'outside' %}
+                {% elseif item.autoClose is same as true %}
+                    {% set _autoClose = 'true' %}
+                {% elseif item.autoClose is same as false %}
+                    {% set _autoClose = 'false' %}
+                {% else %}
+                    {% set _autoClose = item.autoClose %}
+                {% endif %}
                 <div class="dropend">
                     <a class="dropdown-item dropdown-toggle" data-bs-toggle="dropdown" data-bs-auto-close="{{ _autoClose }}" role="button">
                         {{ _title }}


### PR DESCRIPTION
## Description
Add sub dropdown item

<img width="384" height="181" alt="image" src="https://github.com/user-attachments/assets/7f0f2865-ac12-400e-9f5e-207d9899756e" />

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I updated the documentation (see [here](https://github.com/kevinpapst/TablerBundle/tree/master/docs))
- [x] I agree that this code will be published under the [MIT license](https://github.com/kevinpapst/TablerBundle/blob/master/LICENSE)
